### PR TITLE
Ior

### DIFF
--- a/apps/ior/build_ior.sh
+++ b/apps/ior/build_ior.sh
@@ -1,10 +1,33 @@
 #!/bin/bash
 
-sudo yum install -y mpich-devel git automake
-cd /lustre
-git clone https://github.com/LLNL/ior.git
+APP_NAME=ior
+SHARED_APP=/apps
+MODULE_DIR=${SHARED_APP}/modulefiles
+MODULE_NAME=${APP_NAME}
+INSTALL_DIR=${SHARED_APP}/${APP_NAME}
+PARALLEL_BUILD=8
+IOR_GIT_TAG=3.2.1
+
+module load gcc-8.2.0
+module load mpi/mpich-3.3
+
+function create_modulefile {
+mkdir -p ${MODULE_DIR}
+cat << EOF >> ${MODULE_DIR}/${MODULE_NAME}
+#%Module
+prepend-path PATH ${INSTALL_DIR}/bin;
+prepend-path LD_LIBRARY_PATH ${INSTALL_DIR}/lib;
+prepend-path MAN_PATH ${INSTALL_DIR}/share/man;
+EOF
+}
+
+cd /apps
+git clone https://github.com/hpc/ior.git --branch $IOR_GIT_TAG
 cd ior
 ./bootstrap
-MPICC=/usr/lib64/mpich/bin/mpicc ./configure
-make
-cp src/ior /lustre/ior.exe
+
+CC=`which mpicc` ./configure --prefix=${INSTALL_DIR}
+make -j ${PARALLEL_BUILD}
+make install
+
+create_modulefile

--- a/apps/ior/ior.pbs
+++ b/apps/ior/ior.pbs
@@ -1,3 +1,21 @@
 #!/bin/bash
 
-/usr/lib64/mpich/bin/mpirun /lustre/ior.exe -a POSIX -v -B -e -F -r -w -t 32m -b 4G -o /lustre/test.$(date +"%Y-%m-%d_%H-%M-%S")
+SHARED_APPS=/apps
+FILESYSTEM=/beegfs
+
+export MODULEPATH=${SHARED_APPS}/modulefiles:$MODULEPATH
+module load gcc-8.2.0
+module load mpi/mpich-3.3
+module load ior
+
+PKEY=$(grep -v -e 0000 -e 0x7fff --no-filename /sys/class/infiniband/mlx5_0/ports/1/pkeys/*)
+PKEY=${PKEY/0x8/0x0}
+
+# Throughput test (N-N)
+mpirun  -bind-to hwthread  -env UCX_IB_PKEY=$PKEY ior -a POSIX -v -z -i 3 -m -d 1 -B -e -F -r -w -t 32m -b 4G -o ${FILESYSTEM}/test.$(date +"%Y-%m-%d_%H-%M-%S")
+sleep 2
+# Throughput test (N-1)
+mpirun  -bind-to hwthread  -env UCX_IB_PKEY=$PKEY ior -a POSIX -v -z -i 3 -m -d 1 -B -e -r -w -t 32m -b 4G -o ${FILESYSTEM}/test.$(date +"%Y-%m-%d_%H-%M-%S")
+sleep 2
+# IOPS test
+mpirun -bind-to hwthread  -env UCX_IB_PKEY=$PKEY ior -a POSIX -v -z -i 3 -m -d 1 -B -e -F -r -w -t 4k -b 128M -o ${FILESYSTEM}/test.$(date +"%Y-%m-%d_%H-%M-%S")

--- a/apps/ior/mdtest.pbs
+++ b/apps/ior/mdtest.pbs
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+SHARED_APPS=/apps
+FILESYSTEM=/beegfs
+DIRECTORY=${FILESYSTEM}/testing
+NUMFILES=10000
+
+export MODULEPATH=${SHARED_APPS}/modulefiles:$MODULEPATH
+module load gcc-8.2.0
+module load mpi/mpich-3.3
+# ior environment contains mdtest also.
+module load ior
+
+PKEY=$(grep -v -e 0000 -e 0x7fff --no-filename /sys/class/infiniband/mlx5_0/ports/1/pkeys/*)
+PKEY=${PKEY/0x8/0x0}
+
+# Metadata test
+mpirun  -bind-to hwthread  -env UCX_IB_PKEY=$PKEY mdtest -n $NUMFILES -d $DIRECTORY -i 3 -u

--- a/apps/ior/readme.md
+++ b/apps/ior/readme.md
@@ -1,14 +1,19 @@
-# IOR
+# IOR and mdtest
 
-This requires the `mpich` package to be installed on the VMs which run.
+This requires ior to be built on HB or HC sku's with CentOS-HPC 7.6 (using mpi/mpich-3.3)
 
-First build IOR from the build script.  This will put it in `/lustre/ior.exe`:
+First build IOR from the build script.  This will install ior/mdtest in /apps/ior and create a modulefile:
 
     build_ior.sh
 
-Now submit and run:
+Now submit and run (e.g on HB):
 
-     qsub -l select=4:ncpus=1:mpiprocs=16,place=scatter:excl ior.pbs
+     qsub -l select=2:ncpus=60:mpiprocs=15 ior.pbs
 
-> Note: this will run on 4 node and 16 processes per node.
+> Note: this will run on 2 node and 15 processes per node.
 
+The ior.pbs script runs a throughput (N-N and N-1) and IOPS test.
+
+A metadata I/O benchmark test can be run using the mdtest.pbs script.
+
+      qsub -l select=2:ncpus=60:mpiprocs=15 mdtest.pbs


### PR DESCRIPTION
- Use newer ior repo for installation (Include building mdtest), create ior modulefile

- Build ior/mdtest with mpi/mpich-3.3 (on CentOS-HPC 7.6 image)

- Added N-1 throughput and IOPS I/O benchmark

- Added metadata test (mdtest)