### PR TITLE
Fio single node benchmark test

### DIFF
--- a/apps/fio/build_fio.sh
+++ b/apps/fio/build_fio.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+APP_NAME=fio
+SHARED_APP=/apps
+MODULE_DIR=${SHARED_APP}/modulefiles
+MODULE_NAME=${APP_NAME}
+INSTALL_DIR=${SHARED_APP}/${APP_NAME}
+PARALLEL_BUILD=4
+
+function create_modulefile {
+mkdir -p ${MODULE_DIR}
+cat << EOF >> ${MODULE_DIR}/${MODULE_NAME}
+#%Module
+prepend-path PATH ${INSTALL_DIR}/bin;
+prepend-path LD_LIBRARY_PATH ${INSTALL_DIR}/lib;
+prepend-path MAN_PATH ${INSTALL_DIR}/man;
+EOF
+}
+
+yum install -y zlib-devel
+cd $SHARED_APP
+git clone git@github.com:axboe/fio.git
+
+cd $APP_NAME
+./configure --prefix=${INSTALL_DIR}
+make -j $PARALLEL_BUILD
+make install
+
+create_modulefile

--- a/apps/fio/fio.pbs
+++ b/apps/fio/fio.pbs
@@ -20,9 +20,8 @@ else
 fi
 for RW in write read
 do
-# Throughput
 fio --name=${RW}_${SIZE} --directory=$DIRECTORY --direct=1 --size=$SIZE --bs=$BS --rw=${RW} --numjobs=$NUMJOBS --group_reporting --runtime=${RUNTIME} --output=fio_direct_${RW}_${SIZE}_${BS}_${PBS_JOBID}.out
-rm ${DIRECTORY}/testing/*
+rm ${DIRECTORY}/*
 sleep 2
 #
 done

--- a/apps/fio/fio.pbs
+++ b/apps/fio/fio.pbs
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+SHARED_APPS=/apps
+FILESYSTEM=/beegfs
+DIRECTORY=${FILESYSTEM}/testing
+RUNTIME=600
+
+export MODULEPATH=${SHARED_APPS}/modulefiles:$MODULEPATH
+module load fio
+
+mkdir $DIRECTORY
+NUMJOBS=`cat $PBS_NODEFILE | wc -l`
+
+for BS in 4K 4M
+do
+if [ $BS == "4K" ]; then
+   SIZE=128M
+else
+   SIZE=2G
+fi
+for RW in write read
+do
+# Throughput
+fio --name=${RW}_${SIZE} --directory=$DIRECTORY --direct=1 --size=$SIZE --bs=$BS --rw=${RW} --numjobs=$NUMJOBS --group_reporting --runtime=${RUNTIME} --output=fio_direct_${RW}_${SIZE}_${BS}_${PBS_JOBID}.out
+rm ${DIRECTORY}/testing/*
+sleep 2
+#
+done
+done

--- a/apps/fio/readme.md
+++ b/apps/fio/readme.md
@@ -1,0 +1,38 @@
+# FIO
+
+Fio is a general I/O benchmark code, it has many options to configure and customize the I/O pattern being tested.
+
+To build a cluster with PBS, see one of the examples, e.g. [simple_hpc_pbs](../../examples/simple_hpc_pbs/readme.md)
+
+First log-in to the headnode.
+```
+    azhpc-connect headnode
+```
+
+Build fio from the build script.  This will build and install it in `/apps/fio` and create a module file.
+
+```
+    build_fio.sh
+```
+
+Now submit and run:
+
+```
+     qsub -l select=1:ncpus=60:mpiprocs=8 fio.pbs
+```
+> Note: this will run on 1 node, 8 fio processes (fio numjobs). Fio can run on multiple nodes in a client-server mode, this example is designed to run on a single node. You can change the fio numjobs parameter (i.e number of processes) by changing the PBS mpiprocs value. A throughput and IOPS benchmark will be run.
+
+
+A similar script is provided to run the same fio benchmark (throguhput and IOPS) on a Windows client.
+
+A Windows fio executable can be downloaded from
+```
+    https://bsdio.com/fio/
+```
+
+Run the Windows_fio.ps1 powershell script from a Windows powershell prompt.
+```
+    windows_fio.ps1
+```
+> Note: You may need to modify the DIRECTORY and ALLJOBS variables in the windows_fio.ps1 script to reflect the location of the drive you want to test and the number of jobs wou want to run on the windows client.
+

--- a/apps/fio/readme.md
+++ b/apps/fio/readme.md
@@ -4,7 +4,12 @@ Fio is a general I/O benchmark code, it has many options to configure and custom
 
 To build a cluster with PBS, see one of the examples, e.g. [simple_hpc_pbs](../../examples/simple_hpc_pbs/readme.md)
 
-First log-in to the headnode.
+Copy the apps directory to the cluster.
+```
+    azhpc-scp -r $azhpc_dir/apps hpcuser@headnode:.
+```
+
+Connect to the headnode
 ```
     azhpc-connect headnode
 ```

--- a/apps/fio/readme.md
+++ b/apps/fio/readme.md
@@ -9,7 +9,7 @@ First log-in to the headnode.
     azhpc-connect headnode
 ```
 
-Build fio from the build script.  This will build and install it in `/apps/fio` and create a module file.
+Build fio from the build script.  This will build and install it in `/apps/fio` and create a modulefile.
 
 ```
     build_fio.sh
@@ -23,14 +23,14 @@ Now submit and run:
 > Note: this will run on 1 node, 8 fio processes (fio numjobs). Fio can run on multiple nodes in a client-server mode, this example is designed to run on a single node. You can change the fio numjobs parameter (i.e number of processes) by changing the PBS mpiprocs value. A throughput and IOPS benchmark will be run.
 
 
-A similar script is provided to run the same fio benchmark (throguhput and IOPS) on a Windows client.
+A similar script is provided to run the same fio benchmark (throughput and IOPS) on a Windows client.
 
 A Windows fio executable can be downloaded from
 ```
     https://bsdio.com/fio/
 ```
 
-Run the Windows_fio.ps1 powershell script from a Windows powershell prompt.
+Run the windows_fio.ps1 powershell script from a Windows powershell prompt.
 ```
     windows_fio.ps1
 ```

--- a/apps/fio/windows_fio.ps1
+++ b/apps/fio/windows_fio.ps1
@@ -1,0 +1,50 @@
+# Run fio benchmark
+#
+#$DIRECTORY="Z\:\numtargets_8"
+$DIRECTORY="Z\:\."
+$ALLJOBS = 1 2 4 8 16 32 64
+#
+$DIRECTORY2 = $DIRECTORY.replace("\:",":")
+$BS_THROUGHPUT = "4M"
+$BS_IOPS = "4K"
+$SIZE_THROUGHPUT = "2G"
+$SIZE_IOPS = "128M"
+#
+#
+foreach ($NUMJOBS in $ALLJOBS)
+{
+Write-Host "NUMJOBS=$NUMJOBS"
+#
+# throughput BM (multiple jobs)
+#
+$NAME = "throughput"
+$FULLPATH = $DIRECTORY2 + "\" + $NAME + "*"
+$BS = $BS_THROUGHPUT
+$SIZE = $SIZE_THROUGHPUT
+$RW = "write"
+$OUTPUT = "fio" + "_" + $RW + "_" + $NAME + "_" + $BS + "_" + $SIZE + "_" + $NUMJOBS + ".out"
+fio --name=$NAME --rw=$RW --bs=$BS --size=$SIZE --direct=1 --directory=$DIRECTORY --numjobs=$NUMJOBS --group_reporting --output=$OUTPUT
+rm $FULLPATH
+Start-Sleep 2
+$RW = "read"
+$OUTPUT = "fio" + "_" + $RW + "_" + $NAME + "_" + $BS + "_" + $SIZE + "_" + $NUMJOBS + ".out"
+fio --name=$NAME --rw=$RW --bs=$BS --size=$SIZE --direct=1 --directory=$DIRECTORY --numjobs=$NUMJOBS --group_reporting --output=$OUTPUT
+rm $FULLPATH
+Start-Sleep 2
+#
+# IOPS BM (multiple jobs)
+#
+$NAME = "iops"
+$FULLPATH = $DIRECTORY2 + "\" + $NAME + "*"
+$BS = $BS_IOPS
+$SIZE = $SIZE_IOPS
+$RW = "write"
+$OUTPUT = "fio" + "_" + $RW + "_" + $NAME + "_" + $BS + "_" + $SIZE + "_" + $NUMJOBS + ".out"
+fio --name=$NAME --rw=$RW --bs=$BS --size=$SIZE --direct=1 --directory=$DIRECTORY --numjobs=$NUMJOBS --group_reporting --output=$OUTPUT
+rm $FULLPATH
+Start-Sleep 2
+$RW = "read"
+$OUTPUT = "fio" + "_" + $RW + "_" + $NAME + "_" + $BS + "_" + $SIZE + "_" + $NUMJOBS + ".out"
+fio --name=$NAME --rw=$RW --bs=$BS --size=$SIZE --direct=1 --directory=$DIRECTORY --numjobs=$NUMJOBS --group_reporting --output=$OUTPUT
+rm $FULLPATH
+}


### PR DESCRIPTION
-  Script to install fio from git repo.

- PBS script to run an fio throughput and IOPS benchmark on a single Linux client.

- Powershell script to run the same fio I/O benchmark (throughput and IOPS) on a windows client.