### PR TITLE
double curly brace for substitution in config

### DIFF
--- a/tests/test.json
+++ b/tests/test.json
@@ -1,0 +1,7 @@
+{
+	"variables": {
+		"foo": "foo{{variables.bar}}",
+		"bar": "bar{{variables.baz}}",
+		"baz": "baz"
+	}
+}

--- a/tests/test_double_curly_brace.sh
+++ b/tests/test_double_curly_brace.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+source ../libexec/common.sh
+
+DEBUG_ON=0
+COLOR_ON=1
+
+config_file=test.json
+
+function test_read_value
+{
+    read_value_str=$1
+    expected_val=$2
+    echo -n "testing read_value [ $1 = $2 ]... "
+    read_value val "$read_value_str"
+    if [ "$val" = "$expected_val" ]; then
+        echo "SUCCESS"
+    else
+        echo "FAILURE [ value = \"$val\" ]"
+    fi
+}
+
+test_read_value .variables.baz baz
+test_read_value .variables.bar barbaz
+test_read_value .variables.foo foobarbaz


### PR DESCRIPTION
You can use double curly braces anywhere in the value for it to be replace (and multiple are allowed, just not nested in the same string)