### PR TITLE
Added fixes to azhpc-build for partially completed builds

### DIFF
--- a/scripts/pbsclient.sh
+++ b/scripts/pbsclient.sh
@@ -3,13 +3,17 @@
 # arg: $1 = pbs_server
 pbs_server=$1
 
-sudo yum install -y pbspro-execution-19.1.1-0.x86_64.rpm
+if [ "$(rpm -qa pbspro-execution)" = "" ];then
+    sudo yum install -y pbspro-execution-19.1.1-0.x86_64.rpm
 
-sudo sed -i "s/CHANGE_THIS_TO_PBS_PRO_SERVER_HOSTNAME/${pbs_server}/g" /etc/pbs.conf
-sudo sed -i "s/CHANGE_THIS_TO_PBS_PRO_SERVER_HOSTNAME/${pbs_server}/g" /var/spool/pbs/mom_priv/config
-sudo sed -i "s/^if /#if /g" /opt/pbs/lib/init.d/limits.pbs_mom
-sudo sed -i "s/^fi/#fi /g" /opt/pbs/lib/init.d/limits.pbs_mom
-sudo systemctl enable pbs
-sudo systemctl start pbs
+    sudo sed -i "s/CHANGE_THIS_TO_PBS_PRO_SERVER_HOSTNAME/${pbs_server}/g" /etc/pbs.conf
+    sudo sed -i "s/CHANGE_THIS_TO_PBS_PRO_SERVER_HOSTNAME/${pbs_server}/g" /var/spool/pbs/mom_priv/config
+    sudo sed -i "s/^if /#if /g" /opt/pbs/lib/init.d/limits.pbs_mom
+    sudo sed -i "s/^fi/#fi /g" /opt/pbs/lib/init.d/limits.pbs_mom
+    sudo systemctl enable pbs
+    sudo systemctl start pbs
 
-/opt/pbs/bin/qmgr -c "c n $(hostname)"
+    /opt/pbs/bin/qmgr -c "c n $(hostname)"
+else
+    echo "PBS client was already installed"
+fi

--- a/scripts/pbsdownload.sh
+++ b/scripts/pbsdownload.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
-wget http://wpc.23a7.iotacdn.net/8023A7/origin2/rl/PBS-Open/pbspro_19.1.1.centos7.zip
-unzip pbspro_19.1.1.centos7.zip
+filename=pbspro_19.1.1.centos7.zip
+if [ ! -f "$filename" ];then
+    wget http://wpc.23a7.iotacdn.net/8023A7/origin2/rl/PBS-Open/pbspro_19.1.1.centos7.zip
+    unzip pbspro_19.1.1.centos7.zip
+fi
 

--- a/scripts/pbsserver.sh
+++ b/scripts/pbsserver.sh
@@ -2,9 +2,13 @@
 
 admin_user=$(whoami)
 
-sudo yum install -y pbspro-server-19.1.1-0.x86_64.rpm
-sudo systemctl enable pbs
-sudo systemctl start pbs
-sudo /opt/pbs/bin/qmgr -c "s s managers += ${admin_user}@*"
-sudo /opt/pbs/bin/qmgr -c 's s flatuid=t'
-sudo /opt/pbs/bin/qmgr -c 's s job_history_enable=t'
+if [ "$(rpm -qa pbspro-server)" = "" ];then
+    sudo yum install -y pbspro-server-19.1.1-0.x86_64.rpm
+    sudo systemctl enable pbs
+    sudo systemctl start pbs
+    sudo /opt/pbs/bin/qmgr -c "s s managers += ${admin_user}@*"
+    sudo /opt/pbs/bin/qmgr -c 's s flatuid=t'
+    sudo /opt/pbs/bin/qmgr -c 's s job_history_enable=t'
+else
+    echo "PBSPro already installed"
+fi

--- a/scripts/replace_nfs_with_anf.sh
+++ b/scripts/replace_nfs_with_anf.sh
@@ -19,6 +19,12 @@ chmod 777 $anf_mount_pt/apps
 chmod 777 $anf_mount_pt/data
 chmod 777 $anf_mount_pt/home
 #
-ln -s $anf_mount_pt/apps /apps
-ln -s $anf_mount_pt/data /data
-ln -s $anf_mount_pt/home /share/home
+if [ ! -L /apps ]; then
+    ln -s $anf_mount_pt/apps /apps
+fi
+if [ ! -L /data ]; then
+    ln -s $anf_mount_pt/data /data
+fi
+if [ ! -L /share/home ]; then
+    ln -s $anf_mount_pt/home /share/home
+fi


### PR DESCRIPTION
The scripts would fail if they were run on compute nodes that had already been provisioned. These changes allow azhpc-build to be rerun on the compute nodes without having to delete everything and starting over.