### PR TITLE
Showing the errors in the azhpc-connect

### DIFF
--- a/libexec/azhpc-connect.sh
+++ b/libexec/azhpc-connect.sh
@@ -126,5 +126,5 @@ fi
 if [ "$resource_name" = "$install_node" ]; then
     exec ssh -t -q $SSH_ARGS -i $ssh_private_key $ssh_user@$fqdn "$command"
 else
-    exec ssh -t -q $SSH_ARGS -i $ssh_private_key $ssh_user@$fqdn "ssh -t -q $target \"$command\""
+    exec ssh -t -q $SSH_ARGS -i $ssh_private_key $ssh_user@$fqdn "ssh -t $target \"$command\""
 fi


### PR DESCRIPTION
Removed the '-q' from the inner ssh to make it more obvious if the connect fails