### PR TITLE
Provide specific versions in spack config file packages.yaml

### DIFF
--- a/apps/spack/packages.yaml
+++ b/apps/spack/packages.yaml
@@ -1,10 +1,10 @@
 # -------------------------------------------------------------------------
 packages:
-  openmpi:
+  openmpi@4.0.2:
     modules:
        openmpi@4.0.2%gcc@9.2.0: mpi/openmpi-4.0.2
     buildable: False
-  mvapich2:
+  mvapich2@2.3.2:
     modules:
        mvapich2@2.3.2%gcc@9.2.0: mpi/mvapich2-2.3.2
     buildable: False
@@ -16,7 +16,7 @@ packages:
     paths:
        intel-mpi@2019.5.281: /opt/intel/compilers_and_libraries_2019.5.281/linux/mpi
     buildable: False
-  gcc:
+  gcc@9.2.0:
     modules:
        gcc@9.2.0: gcc-9.2.0
     buildable: False


### PR DESCRIPTION
Better to give specific version of libraries/compilers in spack config file packages.yaml. This will apply the special cases to only those specific versions (and not all versions).
These changes are also required so that namd can build correctly.