### PR TITLE
Update GCC and MPI modules

### DIFF
--- a/apps/opm/flow_norne.sh
+++ b/apps/opm/flow_norne.sh
@@ -6,13 +6,13 @@
 #PBS -joe
 #PBS -l walltime=1800
 
-OMPI_ROOT=openmpi-4.0.1
+OMPI_ROOT=openmpi-4.0.2
 SHARED_APP=/apps
 SHARED_DATA=/data
 source /etc/profile # so we can load modules
 module use $SHARED_APP/modulefiles
 module load opm/v2019.04
-module load gcc-8.2.0
+module load gcc-9.2.0
 module load mpi/$OMPI_ROOT
 
 export OPAL_PREFIX=$MPI_HOME


### PR DESCRIPTION
The HPC image must have changed to include gcc-9.2.0 and openmpi-4.0.2 rather than gcc-8.2.0 and openmpi-4.0.1 respectively. Need to load those modules now instead of the old.

{{{
[hpcuser@compute000000 ~]$ module av

---------------------------------------------------------------------------------------------------------------------------------------------------------------------- /usr/share/Modules/modulefiles ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
dot                 gcc-9.2.0           module-git          module-info         modules             mpi/hpcx            mpi/hpcx-v2.5.0     mpi/impi            mpi/impi-2019       mpi/impi_2018.4.274 mpi/impi_2019.5.281 mpi/mvapich2        mpi/mvapich2-2.3.2  mpi/openmpi         mpi/openmpi-4.0.2   null                use.own
}}}