### PR TITLE
Remove `downloadURL` and `cyclecloudVersion` args

### DIFF
--- a/scripts/cc_install.sh
+++ b/scripts/cc_install.sh
@@ -104,8 +104,6 @@ ssh $SSH_ARGS -q -i $ssh_private_key $admin_user@$fqdn "sudo python cyclecloud_i
     --applicationId $appId \
     --tenantId $tenantId \
     --azureSovereignCloud public \
-    --downloadURL $downloadURL \
-    --cyclecloudVersion $release \
     --username $admin_user \
     --hostname $fqdn \
     --acceptTerms  \


### PR DESCRIPTION
Error deploying vanilla cyclecloud instance. 
{{{
Get cyclecloud_install.py
Run cyclecloud_install.py on cycleserver990507.southcentralus.cloudapp.azure.com
Creating temp directory /tmp/tmpH8Zc2H for installing CycleCloud
usage: cyclecloud_install.py [-h] [--azureSovereignCloud AZURESOVEREIGNCLOUD]
                             [--tenantId TENANTID]
                             [--applicationId APPLICATIONID]
                             [--applicationSecret APPLICATIONSECRET]
                             [--username USERNAME] [--hostname HOSTNAME]
                             [--acceptTerms] [--password PASSWORD]
                             [--storageAccount STORAGEACCOUNT]
cyclecloud_install.py: error: unrecognized arguments: --downloadURL https://cyclecloudarm.azureedge.net/cyclecloudrelease --cyclecloudVersion latest
Error : Error installing Cycle Cloud
}}}

Looks like the latest version of `cyclecloud_install.py` doesn't support the `downloadURL` and `cyclecloudVersion` arguments
{{{
$ sudo python azhpc_install_config/cyclecloud_install.py --help
Creating temp directory /tmp/tmpuk8HIX for installing CycleCloud
usage: cyclecloud_install.py [-h] [--azureSovereignCloud AZURESOVEREIGNCLOUD]
                             [--tenantId TENANTID]
                             [--applicationId APPLICATIONID]
                             [--applicationSecret APPLICATIONSECRET]
                             [--username USERNAME] [--hostname HOSTNAME]
                             [--acceptTerms] [--password PASSWORD]
                             [--storageAccount STORAGEACCOUNT]
}}}

Removed them and my cluster is ready to go.