### PR TITLE
Add the possibility for cyclecloud to be installed without public-ip

### DIFF
--- a/libexec/install_helper.sh
+++ b/libexec/install_helper.sh
@@ -384,4 +384,9 @@ function build_hostlists
         fi
 
     done
+
+    read_value dns_prefix ".vnet.dns_domain" NOT-SET
+    if [ "$dns_prefix" != "NOT-SET" ]; then
+        find $tmp_dir/hostlists -type f | xargs sed -i "s/\$/.$dns_prefix/g"
+    fi
 }

--- a/scripts/cc_install.sh
+++ b/scripts/cc_install.sh
@@ -110,13 +110,12 @@ echo "Get cyclecloud_install.py"
 downloadURL="https://cyclecloudarm.azureedge.net/cyclecloudrelease"
 release="latest"
 echo wget "$downloadURL/$release/cyclecloud_install.py" -O cyclecloud_install.py
-wget -v "$downloadURL/$release/cyclecloud_install.py" -O cyclecloud_install.py
+wget -q "$downloadURL/$release/cyclecloud_install.py" -O cyclecloud_install.py
 
 echo "Run cyclecloud_install.py on $fqdn"
-
-scp -vvv $SSH_ARGS -i $ssh_private_key cyclecloud_install.py $admin_user@$source_vm:.
-ssh -vvv $SSH_ARGS -i $ssh_private_key $admin_user@$source_vm "scp $SSH_ARGS cyclecloud_install.py $admin_user@$fqdn:."
-ssh -vvv $SSH_ARGS -i $ssh_private_key $admin_user@$source_vm "ssh -vvv $SSH_ARGS $admin_user@$fqdn 'sudo python cyclecloud_install.py \
+scp -q $SSH_ARGS -i $ssh_private_key cyclecloud_install.py $admin_user@$source_vm:.
+ssh $SSH_ARGS -q -i $ssh_private_key $admin_user@$source_vm "scp $SSH_ARGS cyclecloud_install.py $admin_user@$fqdn:."
+ssh $SSH_ARGS -q -i $ssh_private_key $admin_user@$source_vm "ssh -vvv $SSH_ARGS $admin_user@$fqdn 'sudo python cyclecloud_install.py \
     --applicationSecret ${secret} \
     --applicationId $appId \
     --tenantId $tenantId \

--- a/scripts/cc_install.sh
+++ b/scripts/cc_install.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -x
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SSH_ARGS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -q"
 
@@ -116,7 +115,6 @@ wget -v "$downloadURL/$release/cyclecloud_install.py" -O cyclecloud_install.py
 echo "Run cyclecloud_install.py on $fqdn"
 
 scp -vvv $SSH_ARGS -i $ssh_private_key cyclecloud_install.py $admin_user@$source_vm:.
-echo ssh -vvv $SSH_ARGS -i $ssh_private_key $admin_user@$source_vm "scp $SSH_ARGS cyclecloud_install.py $admin_user@$fqdn:."
 ssh -vvv $SSH_ARGS -i $ssh_private_key $admin_user@$source_vm "scp $SSH_ARGS cyclecloud_install.py $admin_user@$fqdn:."
 ssh -vvv $SSH_ARGS -i $ssh_private_key $admin_user@$source_vm "ssh -vvv $SSH_ARGS $admin_user@$fqdn 'sudo python cyclecloud_install.py \
     --applicationSecret ${secret} \


### PR DESCRIPTION
With this pull request cyclecloud can be installed without public-ip, the requirements for this

- A jumpBox with public-IP
- Setup private DNS (managed by az-hpc)
- a private network for Cycle VM
- Peering between cycle VNET and jumbox VNET (managed by az-hpc)