### PR TITLE
Corrected anf_cifs/ad-config.json

### DIFF
--- a/examples/anf_cifs/ad-config.json
+++ b/examples/anf_cifs/ad-config.json
@@ -1,10 +1,9 @@
 {
   "location": "variables.location",
   "resource_group": "variables.resource_group",
-  "install_from": "jumpbox",
+  "install_from": "",
   "admin_user": "variables.ad_admin",
   "variables": {
-    "image": "OpenLogic:CentOS:7.7:latest",
     "location": "westeurope",
     "resource_group": "ad_demo",
     "vnet_resource_group": "variables.resource_group",
@@ -24,14 +23,6 @@
     }
   },
   "resources": {
-    "jumpbox": {
-      "type": "vm",
-      "public_ip": "true",
-      "vm_type": "Standard_D4_v3",
-      "image": "variables.image",
-      "subnet": "admin",
-      "tags": []
-    },
     "adnode": {
       "type": "vm",
       "public_ip": "true",

--- a/examples/anf_cifs/ad-config.json
+++ b/examples/anf_cifs/ad-config.json
@@ -1,11 +1,10 @@
 {
   "location": "variables.location",
   "resource_group": "variables.resource_group",
-  "install_from": "headnode",
+  "install_from": "jumpbox",
   "admin_user": "variables.ad_admin",
   "variables": {
-    "image": "OpenLogic:CentOS:7.6:latest",
-    "hpc_image": "OpenLogic:CentOS-HPC:7.6:latest",
+    "image": "OpenLogic:CentOS:7.7:latest",
     "location": "westeurope",
     "resource_group": "ad_demo",
     "vnet_resource_group": "variables.resource_group",
@@ -25,6 +24,14 @@
     }
   },
   "resources": {
+    "jumpbox": {
+      "type": "vm",
+      "public_ip": "true",
+      "vm_type": "Standard_D4_v3",
+      "image": "variables.image",
+      "subnet": "admin",
+      "tags": []
+    },
     "adnode": {
       "type": "vm",
       "public_ip": "true",
@@ -35,7 +42,9 @@
       "tags": []
     }
   },
-  "post_install": {
+  "install": [
+    {
+    "type": "local_script",
     "script": "setup_win_ad.sh",
     "args": [
       "variables.resource_group",
@@ -43,6 +52,7 @@
       "variables.ad_domain",
       "variables.ad_admin",
       "variables.win_password"
-    ]
-  }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
The python version currently does not support deploying without a jumpbox/headnode (The ad-config.json technically does not require a jumpbox because it only executes a local_script).

-Added a jumpbox (work-around)
-Changed post-install script to local_script  (Should we support post-install in the python version for backward compatibility?)