### PR TITLE
Changed os and data disk defaults to Premium SSD

### DIFF
--- a/pyazhpc/arm.py
+++ b/pyazhpc/arm.py
@@ -389,9 +389,9 @@ class ArmTemplate:
         ran = res.get("accelerated_networking", False)
         rlowpri = res.get("low_priority", False)
         rosdisksize = res.get("os_disk_size", None)
-        rosstoragesku = res.get("os_storage_sku", "StandardSSD_LRS")
+        rosstoragesku = res.get("os_storage_sku", "Premium_LRS")
         rdatadisks = res.get("data_disks", [])
-        rstoragesku = res.get("storage_sku", "StandardSSD_LRS")
+        rstoragesku = res.get("storage_sku", "Premium_LRS")
         rstoragecache = res.get("storage_cache", "ReadWrite")
         rtags = res.get("resource_tags", {})
         loc = cfg["location"]
@@ -592,9 +592,9 @@ class ArmTemplate:
         ran = res.get("accelerated_networking", False)
         rlowpri = res.get("low_priority", False)
         rosdisksize = res.get("os_disk_size", None)
-        rosstoragesku = res.get("os_storage_sku", "StandardSSD_LRS")
+        rosstoragesku = res.get("os_storage_sku", "Premium_LRS")
         rdatadisks = res.get("data_disks", [])
-        rstoragesku = res.get("storage_sku", "StandardSSD_LRS")
+        rstoragesku = res.get("storage_sku", "Premium_LRS")
         rstoragecache = res.get("storage_cache", "ReadWrite")
         loc = cfg["location"]
         adminuser = cfg["admin_user"]


### PR DESCRIPTION
Changed the default OS and data disk to Premium SSD's so there are no performance surprises when an NFS server or OS disk is created with default settings.