### PR TITLE
PBS cgroup support

### DIFF
--- a/examples/pbs_cgroup/config.json
+++ b/examples/pbs_cgroup/config.json
@@ -1,0 +1,126 @@
+{
+    "location": "variables.location",
+    "resource_group": "variables.resource_group",
+    "install_from": "headnode",
+    "admin_user": "hpcadmin",
+    "variables": {
+        "hpc_image": "<NOT-SET>",
+        "image": "OpenLogic:CentOS:7.7:latest",
+        "location": "southcentralus",
+        "resource_group": "<NOT-SET>",
+        "vm_type": "Standard_ND40rs_v2",
+        "compute_instances": 1,
+        "low_priority": true,
+        "vnet_resource_group": "variables.resource_group"
+    },
+    "vnet": {
+        "resource_group": "variables.vnet_resource_group",
+        "name": "hpcvnet",
+        "address_prefix": "10.2.0.0/20",
+        "subnets": {
+            "compute": "10.2.4.0/22"
+        }
+    },
+    "resources": {
+        "headnode": {
+            "type": "vm",
+            "vm_type": "variables.vm_type",
+            "public_ip": true,
+            "image": "variables.hpc_image",
+            "subnet": "compute",
+            "tags": [
+                "cndefault",
+                "nfsserver",
+                "pbsserver",
+                "loginnode",
+                "localuser",
+                "disable-selinux",
+                "pbs_cgroup",
+                "pbs_restart"
+            ]
+        },
+        "gpu": {
+            "type": "vmss",
+            "vm_type": "variables.vm_type",
+            "instances": "variables.compute_instances",
+            "low_priority": "variables.low_priority",
+            "image": "variables.hpc_image",
+            "subnet": "compute",
+            "tags": [
+                "nfsclient",
+                "pbsclient",
+                "cndefault",
+                "localuser",
+                "disable-selinux",
+                "pbs_restart"
+            ]
+        }
+    },
+    "install": [
+        {
+            "script": "disable-selinux.sh",
+            "tag": "disable-selinux",
+            "sudo": true
+        },
+        {
+            "script": "cndefault.sh",
+            "tag": "cndefault",
+            "sudo": true
+        },
+        {
+            "script": "nfsserver.sh",
+            "tag": "nfsserver",
+            "sudo": true
+        },
+        {
+            "script": "nfsclient.sh",
+            "args": [
+                "$(<hostlists/tags/nfsserver)"
+            ],
+            "tag": "nfsclient",
+            "sudo": true
+        },
+        {
+            "script": "localuser.sh",
+            "args": [
+                "$(<hostlists/tags/nfsserver)"
+            ],
+            "tag": "localuser",
+            "sudo": true
+        },
+        {
+            "script": "pbsdownload.sh",
+            "tag": "loginnode",
+            "sudo": false
+        },
+        {
+            "script": "pbsserver.sh",
+            "copy": [
+                "pbspro_19.1.1.centos7/pbspro-server-19.1.1-0.x86_64.rpm"
+            ],
+            "tag": "pbsserver",
+            "sudo": false
+        },
+        {
+            "script": "pbsclient.sh",
+            "args": [
+                "$(<hostlists/tags/pbsserver)"
+            ],
+            "copy": [
+                "pbspro_19.1.1.centos7/pbspro-execution-19.1.1-0.x86_64.rpm"
+            ],
+            "tag": "pbsclient",
+            "sudo": false
+        },
+        {
+            "script": "pbs_cgroup.sh",
+            "tag": "pbs_cgroup",
+            "sudo": true
+        },
+        {
+            "script": "pbs_restart.sh",
+            "tag": "pbs_restart",
+            "sudo": true
+        }
+    ]
+}

--- a/examples/pbs_cgroup/readme.md
+++ b/examples/pbs_cgroup/readme.md
@@ -73,4 +73,4 @@ nvidia-smi
 +-------------------------------+----------------------+----------------------+
 ```
 
->Note: A job run on there requested resources will only use 2 gpu's, 10 cpu cores and 160 GB of memory.
+>Note: A job run on there requested resources will only use 2 gpu's, 10 cpu cores and 160 GB of memory. Wth Cgroups its improtant to specify how much memory you need because the default memory setting is very low.

--- a/examples/pbs_cgroup/readme.md
+++ b/examples/pbs_cgroup/readme.md
@@ -1,0 +1,76 @@
+# Example of PBS Cgroup
+
+Visualisation: [config.json](https://azurehpc.azureedge.net/?o=https://raw.githubusercontent.com/Azure/azurehpc/master/examples/pbs_cgroup/config.json)
+
+This example will create an HPC cluster ready to run with PBS Pro with the Cgroup hook enabled. This will allow you to have more fine control over your resources. This is especially useful with the ND40rs_v2 sku, it has 40 cores, 8xv100 and 650 GB of memory. PBS Cgroups allows you to carve up this VM into smaller chunks (e.g Run a job on 2 gpu's, 10 cpu cores and 160GB of memory)
+
+## Initialise the project
+
+To start you need to copy this directory and update the `config.json`.  Azurehpc provides the `azhpc-init` command that can help here by compying the directory and substituting the unset variables.  First run with the `-s` parameter to see which variables need to be set:
+
+```
+azhpc-init -c $azhpc_dir/examples/pbs_cgroup -d pbs_cgroup -s
+```
+
+The variables can be set with the `-v` option where variables are comma separated.  The output from the previous command as a starting point.  The `-d` option is required and will create a new directory name for you.  Please update to whatever `resource_group` you would like to deploy to:
+> Note: The ND40rs_v2 (8xv100) resuires a custom image (with nividia drivers installed and IB enabled).
+
+```
+azhpc-init -c $azhpc_dir/examples/pbs_cgroup -d pbs_cgroup -v resource_group=azurehpc-cluster
+```
+
+> Note:  You can still update variables even if they are already set.  For example, in the command below we change the region to `westus2` and the SKU to `Standard_HC44rs`:
+
+```
+azhpc-init -c $azhpc_dir/examples/pbs_cgroup -d pbs_cgroup -v location=westus2,vm_type=Standard_HC44rs,resource_group=azhpc-cluster
+```
+
+## Create the cluster 
+
+```
+cd simple_hpc_pbs
+azhpc-build
+```
+
+Allow ~10 minutes for deployment.  You are able to view the status VMs being deployed by running `azhpc-status` in another terminal.
+
+## Log in the cluster
+
+Connect to the headnode and check PBS
+
+```
+$ azhpc-connect -u hpcuser headnode
+Fri Jun 28 09:18:04 UTC 2019 : logging in to headnode (via headnode6cfe86.westus2.cloudapp.azure.com)
+[hpcuser@headnode ~]$ pbsnodes -avS
+vnode           state           OS       hardware host            queue        mem     ncpus   nmics   ngpus  comment
+--------------- --------------- -------- -------- --------------- ---------- -------- ------- ------- ------- ---------
+gpu000001       free            --       --       gpu000001       --            661gb      40       0       8 --
+
+```
+
+Use cgroups to get 2 gpu's, 10 cpus and 160GB of memory
+
+```
+qsub -I -l select=1:ncpus=10:ngpus=2:mem=160gb
+```
+
+Check that you only get 2 gpus
+
+```
+nvidia-smi
+
++-----------------------------------------------------------------------------+
+| NVIDIA-SMI 440.64.00    Driver Version: 440.64.00    CUDA Version: 10.2     |
+|-------------------------------+----------------------+----------------------+
+| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
+|===============================+======================+======================|
+|   0  Tesla V100-SXM2...  Off  | 0000B57E:00:00.0 Off |                    0 |
+| N/A   38C    P0    55W / 300W |      0MiB / 32510MiB |      0%      Default |
++-------------------------------+----------------------+----------------------+
+|   1  Tesla V100-SXM2...  Off  | 0000EE58:00:00.0 Off |                    0 |
+| N/A   41C    P0    54W / 300W |      0MiB / 32510MiB |      5%      Default |
++-------------------------------+----------------------+----------------------+
+```
+
+>Note: A job run on there requested resources will only use 2 gpu's, 10 cpu cores and 160 GB of memory.

--- a/examples/pbs_cgroup/readme.md
+++ b/examples/pbs_cgroup/readme.md
@@ -73,4 +73,4 @@ nvidia-smi
 +-------------------------------+----------------------+----------------------+
 ```
 
->Note: A job run on there requested resources will only use 2 gpu's, 10 cpu cores and 160 GB of memory. Wth Cgroups its improtant to specify how much memory you need because the default memory setting is very low.
+>Note: A job run on the requested resources will only use 2 gpu's, 10 cpu cores and 160 GB of memory. Wth Cgroups its important to specify how much memory you need because the default memory setting is very low.

--- a/scripts/pbs_cgroup.sh
+++ b/scripts/pbs_cgroup.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+/opt/pbs/bin/qmgr -c "export hook pbs_cgroups application/x-config default" > pbs_cgroups.json
+
+tmp=$(mktemp)
+jq '.cgroup.devices.enabled = true' pbs_cgroups.json > $tmp && mv $tmp pbs_cgroups.json
+jq '.cgroup.devices.allow = [ "b *:* rwm","c 10:* rwm","c 4:* rwm","c 5:* rwm","c 1:* rwm","c 7:* rwm",["nvidia-uvm", "rwm"]]' pbs_cgroups.json > $tmp && mv $tmp pbs_cgroups.json
+
+/opt/pbs/bin/qmgr -c "import hook pbs_cgroups application/x-config default pbs_cgroups.json"
+
+/opt/pbs/bin/qmgr -c "export hook pbs_cgroups application/x-python default" > pbs_cgroups.py
+
+cat > pbs_cgroups_py.patch << EOF
+--- pbs_cgroups.py_orig 2020-04-08 20:05:31.573683390 +0000
++++ pbs_cgroups.py      2020-04-08 20:09:50.388237101 +0000
+@@ -780,6 +780,7 @@
+                 if gpus:
+                     # Don't put quotes around the values. ex "0" or "0,1".
+                     # This will cause it to fail.
++                    gpus = range(0,len(gpus))
+                     env_list.append('CUDA_VISIBLE_DEVICES=%s' %
+                                     string.join(gpus, ','))
+             pbs.logmsg(pbs.EVENT_DEBUG4, 'ENV_LIST: %s' % env_list)
+@@ -1014,6 +1015,7 @@
+                 if gpus:
+                     # Don't put quotes around the values. ex "0" or "0,1".
+                     # This will cause it to fail.
++                    gpus=range(0,len(gpus))
+                     env_list.append('CUDA_VISIBLE_DEVICES=%s' %
+                                     string.join(gpus, ','))
+             pbs.logmsg(pbs.EVENT_DEBUG4, 'ENV_LIST: %s' % env_list)
+@@ -2887,6 +2889,7 @@
+                 pbs.logmsg(pbs.EVENT_DEBUG4,
+                            'offload_devices: %s' % offload_devices)
+             if cuda_visible_devices:
++                cuda_visible_devices = range(0,len(cuda_visible_devices))
+                 value = string.join(cuda_visible_devices, '\\,')
+                 pbs.event().env['CUDA_VISIBLE_DEVICES'] = '%s' % value
+                 pbs.logmsg(pbs.EVENT_DEBUG4,
+EOF
+
+patch -p0 < pbs_cgroups.patch
+
+/opt/pbs/bin/qmgr -c "import hook pbs_cgroups application/x-python default" pbs_cgroups.py
+
+/opt/pbs/bin/qmgr -c "set hook pbs_cgroups enabled = true"
+
+sed -i 's/^resources:.*/resources: "ncpus, pool_name, mem, arch, host, vnode, aoe, eoe, ngpus"/' /var/spool/pbs/sched_priv/sched_config

--- a/scripts/pbs_restart.sh
+++ b/scripts/pbs_restart.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+systemctl restart pbs


### PR DESCRIPTION
-Added support for PBS cgroups
-Added example using PBS cgroups with ND40rs_v2 (divide resource into smaller units (e.g submit job on 2 gpus, 10 cpu cores and 160 GB of memory)