### PR TITLE
Beegfs bug fix (due to change to premium disks)

### DIFF
--- a/examples/beegfs/config.json
+++ b/examples/beegfs/config.json
@@ -66,7 +66,7 @@
         },
         "beegfsm": {
             "type": "vm",
-            "vm_type": "Standard_D4_v3",
+            "vm_type": "Standard_D4s_v3",
             "accelerated_networking": true,
             "image": "variables.image",
             "subnet": "compute",

--- a/examples/beegfs_data_disk/config.json
+++ b/examples/beegfs_data_disk/config.json
@@ -64,7 +64,7 @@
         },
         "beegfsm": {
             "type": "vm",
-            "vm_type": "Standard_D4_v3",
+            "vm_type": "Standard_D4s_v3",
             "accelerated_networking": true,
             "image": "variables.image",
             "subnet": "compute",

--- a/examples/beegfs_local_ssd/config.json
+++ b/examples/beegfs_local_ssd/config.json
@@ -66,7 +66,7 @@
         },
         "beegfsm": {
             "type": "vm",
-            "vm_type": "Standard_D4_v3",
+            "vm_type": "Standard_D4s_v3",
             "accelerated_networking": true,
             "image": "variables.image",
             "subnet": "compute",

--- a/examples/beegfs_pools/config.json
+++ b/examples/beegfs_pools/config.json
@@ -65,7 +65,7 @@
         },
         "beegfsm": {
             "type": "vm",
-            "vm_type": "Standard_D4_v3",
+            "vm_type": "Standard_D4s_v3",
             "accelerated_networking": true,
             "image": "variables.image",
             "subnet": "compute",


### PR DESCRIPTION
The D3_v3 sku does not support premium disks. This sku was used as BeeGFS management node. This PR changes it to D4s_v3 (which supports premium disks).