### PR TITLE
Beegfs bug fix (Change default repo to be 7_1)

### DIFF
--- a/scripts/beegfsc.sh
+++ b/scripts/beegfsc.sh
@@ -7,7 +7,7 @@ yum install -y beegfs-client beegfs-helperd beegfs-utils
 
 sed -i 's/^sysMgmtdHost.*/sysMgmtdHost = '$MGMT_HOSTNAME'/g' /etc/beegfs/beegfs-client.conf
 if [ -d "/usr/src/ofa_kernel/default/include" ]; then
-sed -i 's/^buildArgs=.*/buildArgs=-j8 OFED_INCLUDE_PATH=/usr/src/ofa_kernel/default/include/g' /etc/beegfs/beegfs-client-autobuild.conf
+sed -i 's#^buildArgs=.*#buildArgs=-j8 OFED_INCLUDE_PATH=/usr/src/ofa_kernel/default/include#g' /etc/beegfs/beegfs-client-autobuild.conf
 fi
 echo "$SHARE_SCRATCH /etc/beegfs/beegfs-client.conf" > /etc/beegfs/beegfs-mounts.conf
 

--- a/scripts/beegfsc.sh
+++ b/scripts/beegfsc.sh
@@ -6,6 +6,9 @@ SHARE_SCRATCH=/beegfs
 yum install -y beegfs-client beegfs-helperd beegfs-utils
 
 sed -i 's/^sysMgmtdHost.*/sysMgmtdHost = '$MGMT_HOSTNAME'/g' /etc/beegfs/beegfs-client.conf
+if [ -d "/usr/src/ofa_kernel/default/include" ]; then
+sed -i 's/^buildArgs=.*/buildArgs=-j8 OFED_INCLUDE_PATH=/usr/src/ofa_kernel/default/include/g' /etc/beegfs/beegfs-client-autobuild.conf
+fi
 echo "$SHARE_SCRATCH /etc/beegfs/beegfs-client.conf" > /etc/beegfs/beegfs-mounts.conf
 
 systemctl daemon-reload

--- a/scripts/beegfspkgs.sh
+++ b/scripts/beegfspkgs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-BEEGFS_VER=${1-7_1.713}
+BEEGFS_VER=${1-7_1}
 
 RELEASE=$(cat /etc/redhat-release | cut -d' ' -f4)
 KERNEL=$(uname -r)


### PR DESCRIPTION
-Changed default BeeGFS repo to be 7_1 (7_1.713 no longer exists)
-Resolved IB undefined symbols (Added IB include path, when building client)