### PR TITLE
make_filesystem modification

### DIFF
--- a/scripts/make_filesystem.sh
+++ b/scripts/make_filesystem.sh
@@ -34,3 +34,4 @@ esac
 sleep 10
 mkdir -p $mount
 mount $mount
+chmod 777 $mount


### PR DESCRIPTION
Changed permission of mounted filesystem.

When using make_filesystem.sh to mount HB120rs_v2 nvme local ssh, I could not write because I did not have permission.