### PR TITLE
Support Intel MPI in spack.

### DIFF
--- a/apps/spack/build_spack.sh
+++ b/apps/spack/build_spack.sh
@@ -3,6 +3,7 @@
 APP_NAME=spack
 APP_VERSION=0.14.2
 SHARED_APP=${SHARED_APP:-/apps}
+INTEL_MPI_VERSION=${INTEL_MPI_VERSION:-2020.1.217}
 USER=`whoami`
 
 sku_type=$1
@@ -11,6 +12,7 @@ STORAGE_ENDPOINT=$3
 
 APPS_SPACK_DIR=`pwd`
 CONFIG_YAML=config.yaml
+PACKAGES_YAML=packages.yaml
 
 sudo yum install -y python3
 
@@ -32,6 +34,8 @@ sudo chown $USER /mnt/resource/spack
 mkdir ~/.spack
 sed -i "s/SKU_TYPE/${sku_type}/" ${APPS_SPACK_DIR}/${CONFIG_YAML}
 sed -i "s#SHARED_APP#${SHARED_APP}#" ${APPS_SPACK_DIR}/${CONFIG_YAML}
+sed -i "s/INTEL_MPI_VERSION/${INTEL_MPI_VERSION}/" ${APPS_SPACK_DIR}/${PACKAGES_YAML}
+
 cp ${APPS_SPACK_DIR}/${CONFIG_YAML} ~/.spack
 cp ${APPS_SPACK_DIR}/packages.yaml ~/.spack
 cp ${APPS_SPACK_DIR}/compilers.yaml ~/.spack

--- a/apps/spack/packages.yaml
+++ b/apps/spack/packages.yaml
@@ -14,7 +14,7 @@ packages:
     buildable: False
   intel-mpi:
     paths:
-       intel-mpi@2019.6.166: /opt/intel/compilers_and_libraries_2019.6.166/linux/mpi
+       intel-mpi@INTEL_MPI_VERSION: /opt/intel/compilers_and_libraries_INTEL_MPI_VERSION/linux/mpi
     buildable: False
   gcc:
     modules:


### PR DESCRIPTION
Support Intel MPI (from CentOS-HPC 7.7 image) in spack.