### PR TITLE
Symlinks copied in azhpc-init

### DIFF
--- a/pyazhpc/azhpc.py
+++ b/pyazhpc/azhpc.py
@@ -86,7 +86,7 @@ def do_init(args):
                         )
                     )
                     log.debug(f"copying file: {oldfile} -> {newfile}")
-                    shutil.copy(oldfile, newfile)
+                    shutil.copy(oldfile, newfile, follow_symlinks=False)
 
         # get vars
         vset = {}


### PR DESCRIPTION
Symlinks are not followed anymore (to fix "trick" with the slurm example
where the scripts dir has a symlink to the yet-to-be-created ssh keys.