### PR TITLE
Change fault domain count to be 1

### DIFF
--- a/pyazhpc/arm.py
+++ b/pyazhpc/arm.py
@@ -678,7 +678,7 @@ class ArmTemplate:
         rppg = res.get("proximity_placement_group", False)
         rppgname = cfg.get("proximity_placement_group_name", None)
         raz = res.get("availability_zones", None)
-        rfaultdomaincount = res.get("fault_domain_count", None)
+        rfaultdomaincount = res.get("fault_domain_count", 1)
         rsubnet = res["subnet"]
         ran = res.get("accelerated_networking", False)
         rlowpri = res.get("low_priority", False)


### PR DESCRIPTION
The default fault domain count is 5.

Large VMSS (300 HC instances in south central us) have failed to deploy when fault domain count is set to 5, but deploys correctly when set to 1.