### PR TITLE
Fix WPS build error

### DIFF
--- a/apps/wrf/install_wps_openmpi.sh
+++ b/apps/wrf/install_wps_openmpi.sh
@@ -28,6 +28,7 @@ module load gcc-9.2.0
 export HDF5=$(spack location -i hdf5^openmpi)
 export NETCDF=$(spack location -i netcdf-fortran^openmpi)
 export WRF_DIR=${SHARED_APP}/${SKU_TYPE}/wrf-openmpi/WRF-${WRF_VERSION}
+export MPI_LIB=""
 
 cd WPS-${APP_VERSION}
 ./configure << EOF


### PR DESCRIPTION
OpenMPI modulefile sets MPI_LIB to the location of the openmpi libraries.
WPS passes in that environmental variable directly (without -L) causing a build error.
WPS uses the mpi wrapper mpif90 to build and so it does not need the variable MPI_LIB because
the wrapper knows the location of the openmpi libraries and include files.
Fix is to unset MPI_LIB after the OpenMPI modulefile sets it (MPI_LIB="").