### PR TITLE
Corrected epel-release installation condition

### DIFF
--- a/scripts/cndefault.sh
+++ b/scripts/cndefault.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Script to be run on all compute nodes
-if rpm -q epel-release; then
+if ! rpm -q epel-release; then
     yum -y install epel-release
 fi
 


### PR DESCRIPTION
The condition is true only if `epel-release` RPM  is already installed. Hence it never gets installed.
This fix has been tested by deploying `simple_hpc_pbs`.