### PR TITLE
PBS automatic deletion of idle vmss instances

### DIFF
--- a/examples/pbs_delete_idle_vmss/config.json
+++ b/examples/pbs_delete_idle_vmss/config.json
@@ -1,0 +1,156 @@
+{
+  "location": "variables.location",
+  "resource_group": "variables.resource_group",
+  "install_from": "headnode",
+  "admin_user": "hpcadmin",
+  "variables": {
+    "image": "OpenLogic:CentOS-HPC:7.7:latest",
+    "hpc_image": "OpenLogic:CentOS-HPC:7.7:latest",
+    "location": "<NOT-SET>",
+    "resource_group": "<NOT-SET>",
+    "compute_vm_type": "Standard_HB120rs_v2",
+    "vm_type": "Standard_D8s_v3",
+    "vnet_resource_group": "variables.resource_group",
+    "pbs_idle_time_mins": 10,
+    "debug_pbs_idle_time": 1
+  },
+  "vnet": {
+    "resource_group": "variables.vnet_resource_group",
+    "name": "hpcvnet",
+    "address_prefix": "10.37.0.0/20",
+    "subnets": {
+      "admin": "10.37.1.0/24",
+      "storage": "10.37.3.0/24",
+      "compute": "10.37.4.0/22"
+    }
+  },
+  "resources": {
+    "headnode": {
+      "type": "vm",
+      "vm_type": "variables.vm_type",
+      "public_ip": true,
+      "image": "variables.image",
+      "data_disks": [2048],
+      "subnet": "compute",
+      "tags": [
+        "cndefault",
+        "nfsserver",
+        "pbsserver",
+        "loginnode",
+        "localuser",
+        "disable-selinux",
+        "azcopy",
+        "azcli",
+        "pbs_delete_idle_vmss"
+      ]
+    },
+    "compute": {
+      "type": "vmss",
+      "vm_type": "variables.compute_vm_type",
+      "instances": 2,
+      "accelerated_networking": false,
+      "low_priority": true,
+      "image": "variables.hpc_image",
+      "subnet": "compute",
+      "tags": [
+        "nfsclient",
+        "pbsclient",
+        "cndefault",
+        "localuser",
+        "disable-selinux"
+      ]
+    },
+    "compute2": {
+      "type": "vmss",
+      "vm_type": "variables.compute_vm_type",
+      "instances": 2,
+      "accelerated_networking": false,
+      "low_priority": true,
+      "image": "variables.hpc_image",
+      "subnet": "compute",
+      "tags": [
+        "nfsclient",
+        "pbsclient",
+        "cndefault",
+        "localuser",
+        "disable-selinux"
+      ]
+    }
+  },
+  "install": [
+    {
+      "script": "disable-selinux.sh",
+      "tag": "disable-selinux",
+      "sudo": true
+    },
+    {
+      "script": "cndefault.sh",
+      "tag": "cndefault",
+      "sudo": true
+    },
+    {
+      "script": "nfsserver.sh",
+      "tag": "nfsserver",
+      "sudo": true
+    },
+    {
+      "script": "nfsclient.sh",
+      "args": [
+        "$(<hostlists/tags/nfsserver)"
+      ],
+      "tag": "nfsclient",
+      "sudo": true
+    },
+    {
+      "script": "localuser.sh",
+      "args": [
+        "$(<hostlists/tags/nfsserver)"
+      ],
+      "tag": "localuser",
+      "sudo": true
+    },
+    {
+      "script": "pbsdownload.sh",
+      "tag": "loginnode",
+      "sudo": false
+    },
+    {
+      "script": "pbsserver.sh",
+      "copy": [
+        "pbspro_19.1.1.centos7/pbspro-server-19.1.1-0.x86_64.rpm"
+      ],
+      "tag": "pbsserver",
+      "sudo": true
+    },
+    {
+      "script": "pbsclient.sh",
+      "args": [
+        "$(<hostlists/tags/pbsserver)"
+      ],
+      "copy": [
+        "pbspro_19.1.1.centos7/pbspro-execution-19.1.1-0.x86_64.rpm"
+      ],
+      "tag": "pbsclient",
+      "sudo": true
+    },
+    {
+      "script": "install-azcopy.sh",
+      "tag": "azcopy",
+      "sudo": true
+    },
+    {
+      "script": "install-azcli.sh",
+      "tag": "azcli",
+      "sudo": true
+    },
+    {
+      "script": "pbs_delete_idle_vmss.sh",
+      "args": [
+        "variables.pbs_idle_time_mins",
+        "variables.debug_pbs_idle_time"
+      ],
+      "tag": "pbs_delete_idle_vmss",
+      "sudo": false
+    }
+  ]
+}

--- a/examples/pbs_delete_idle_vmss/readme.md
+++ b/examples/pbs_delete_idle_vmss/readme.md
@@ -4,6 +4,10 @@ Visualisation: [config.json](https://azurehpc.azureedge.net/?o=https://raw.githu
 
 This example will create an HPC cluster ready to run with PBS Pro. Idle instances in VMSS's will be automatically deleted and removed from PBS (To control resource costs). The default idle period is 10 minutes (Can be changed in the config file). The idle period measurement does not start when the HPC cluster first comes up, it starts when a PBS job completes on a VMSS instance. The script to check for idle VMSS instances runs at intervals defined in the crontab (crontab -l). A logfile is also generated at /tmp/azurehpc_delete_idle_vmss.log_$$ to help monitor/track/debug idle VMSS instances and record what instances have been deleted.
 
+## Prerequisites
+
+azcli is installed on the headnode and azcli is authorized to delete/create azure resources in the subscription you are using (e.g az login).
+
 ## Initialise the project
 
 To start you need to copy this directory and update the `config.json`.  Azurehpc provides the `azhpc-init` command that can help here by compying the directory and substituting the unset variables.  First run with the `-s` parameter to see which variables need to be set:

--- a/examples/pbs_delete_idle_vmss/readme.md
+++ b/examples/pbs_delete_idle_vmss/readme.md
@@ -1,0 +1,30 @@
+# Build a PBS compute cluster with automatic deletion of idle VMSS instances
+
+Visualisation: [config.json](https://azurehpc.azureedge.net/?o=https://raw.githubusercontent.com/Azure/azurehpc/master/examples/pbs_delete_idle_vmss/config.json)
+
+This example will create an HPC cluster ready to run with PBS Pro. Idle instances in VMSS's will be automatically deleted and removed from PBS (To control resource costs). The default idle period is 10 minutes (Can be changed in the config file). The idle period measurement does not start when the HPC cluster first comes up, it starts when a PBS job completes on a VMSS instance. The script to check for idle VMSS instances runs at intervals defined in the crontab (crontab -l). A logfile is also generated at /tmp/azurehpc_delete_idle_vmss.log_$$ to help monitor/track/debug idle VMSS instances and record what instances have been deleted.
+
+## Initialise the project
+
+To start you need to copy this directory and update the `config.json`.  Azurehpc provides the `azhpc-init` command that can help here by compying the directory and substituting the unset variables.  First run with the `-s` parameter to see which variables need to be set:
+
+```
+azhpc-init -c $azhpc_dir/examples/pbs_delete_idle_vmss -d pbs_delete_idle_vmss -s
+```
+
+The variables can be set with the `-v` option where variables are comma separated.  The output from the previous command as a starting point.  The `-d` option is required and will create a new directory name for you.  Please update to whatever `resource_group` you would like to deploy to:
+
+```
+azhpc-init -c $azhpc_dir/examples/pbs_delete_idle_vmss -d pbs_delete_idle_vmss -v resource_group=azurehpc-cluster
+```
+
+## Create the cluster 
+
+```
+cd pbs_delete_idle_vmss
+azhpc-build
+```
+
+Allow ~10 minutes for deployment.  You are able to view the status VMs being deployed by running `azhpc-status` in another terminal.
+
+

--- a/scripts/pbs_delete_idle_vmss.sh
+++ b/scripts/pbs_delete_idle_vmss.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+IDLE_TIME_MINS=${1:-10}
+DEBUG=${2:-1}
+
+LOGFILE=/tmp/azurehpc_delete_idle_vmss.log_$$
+SCRIPT_NAME=/tmp/azurehpc_delete_idle_vmss.sh
+PBSNODES_JSON=/tmp/pbsnodes.json
+NODES_JSON=/tmp/nodes.json
+USER=hpcadmin
+
+cat << EOF >> $SCRIPT_NAME
+#!/bin/bash
+
+echo >> $LOGFILE
+CURRENT_TIME=\`date +%s\`
+IDLE_TIME_SECS=$((IDLE_TIME_MINS*60))
+node_list=""
+
+function get_instance_id() 
+{
+    OLDIFS=\$IFS
+    IFS="_"
+    set -- \$1
+    IFS=\$OLDIFS
+    instanceid=\$2
+}
+
+echo "\`date\`: CURRENT_TIME=\$CURRENT_TIME" >> $LOGFILE
+
+/opt/pbs/bin/pbsnodes -a -F json >& $PBSNODES_JSON
+jq ".nodes | keys" $PBSNODES_JSON >& $NODES_JSON
+
+for node in \`jq -r .[] $NODES_JSON\`
+do
+node_list="\$node_list \$node"
+done
+if [ $DEBUG -eq 1 ]; then
+   echo "\`date\`: node_list=\$node_list" >> $LOGFILE
+fi
+
+for node in \$node_list
+do
+  echo >> $LOGFILE
+  node_lut=\`jq "select(.nodes.\$node.last_used_time) | .nodes.\$node.last_used_time" $PBSNODES_JSON\`
+  node_state=\`jq -r ".nodes.\$node.state" $PBSNODES_JSON\`
+  if [ $DEBUG -eq 1 ]; then
+     echo "\`date\`: VM \$node, PBS last used time = \$node_lut" >> $LOGFILE
+     echo "\`date\`: VM \$node, PBS state = \$node_state" >> $LOGFILE
+  fi
+  if [ ! -z \$node_lut ] && [ \$node_state == "free" ]; then
+    echo "\`date\`: Checking node=\$node" >> $LOGFILE
+    DIFF=\$((CURRENT_TIME-node_lut))
+    if [ $DEBUG -eq 1 ]; then
+       echo "\`date\`: CURRENT_TIME=\$CURRENT_TIME,pbs node state=$node_state,node_lut=\$node_lut,DIFF=\$DIFF" >> $LOGFILE
+    fi
+    if [ \$DIFF -gt \$IDLE_TIME_SECS ]
+    then
+       eval ssh \$node curl -s -H Metadata:true "http://169.254.169.254/metadata/instance/compute?api-version=2019-08-15" | jq . >& /tmp/\${node}.json
+       vmscalesetname=\`jq -r .vmScaleSetName /tmp/\${node}.json\`
+       resourcegroupname=\`jq -r .resourceGroupName /tmp/\${node}.json\`
+       resourceid=\`jq -r .resourceId /tmp/\${node}.json\`
+        if [ $DEBUG -eq 1 ]; then
+           echo "\`date\`: vmscalesetname=\$vmscalesetname,resourcegroupname=\$resourcegroupname,resourceid=\$resourceid" >> $LOGFILE
+        fi
+       get_instance_id \$resourceid
+       if [ $DEBUG -eq 1 ]; then
+          echo "\`date\`: VM=\$node corresponds to InstanceId=\$instanceid" >> $LOGFILE
+       fi
+       echo "\`date\`: removing $node from PBS" >> $LOGFILE
+       sudo /opt/pbs/bin/qmgr -c "d n \$node"
+       echo "\`date\`: Deleting instance \$node from vmss" >> $LOGFILE
+       az vmss delete-instances --instance-ids \$instanceid --name \$vmscalesetname --resource-group \$resourcegroupname --no-wait
+    fi
+  fi
+done
+EOF
+
+chmod 777 $SCRIPT_NAME
+
+crontab -l > mycrontab
+echo "*/$IDLE_TIME_MINS * * * * $SCRIPT_NAME" >> mycrontab
+crontab mycrontab
+crontab -l


### PR DESCRIPTION
The pbs_delete_idle_vmss.sh script generated a script, runs the script at regular intervals (default 10min, can be changed in the config.json) defined by the crontab.

- Runs on headnode (no ssh to compute instances, looks at the PBS resource "last_used_time" and job "status")
- When a PBS job has not run on the VMSS instance for the specified period. The instance will be removed from PBS and deleted.
- Will work with multiple VMSS's
- The instance idle time measurement only starts when a PBS job has completed on the instance. (i.e When the HPC cluster is first deployed the idle measurement does not start).
- A logfile (/tmp/azurehpc_delete_idle_vmss.log_$$) is generated to monitor/debug/record idle instances and what instances have been deleted.