### PR TITLE
Added Cloud-init support in AzureHPC 

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ This dictionary describes the resources for the project.
 | **os_disk_size**           | OS Disk size in GB. This is only needed if you want to use a non default size or increase the OS disk size|   no     |         |
 | **os_storage_sku**         | OS Storage SKU. `Premium_LRS`, `StandardSSD_LRS` or `Standard_LRS`          |   no     |Premium_LRS|
 | **password**               | user admin password to use with Windows                                     |   no     |         |
-| **cloud_init_sasurl**      | SASURL indicating the location of the cloud-init script                     |   no     |  None   |
+| **cloud_init_url**         | URL indicating the location of the cloud-init script                        |   no     |  None   |
 | **proximity_placement_group**| Boolean flag for wether to include the resource in the proximity placement group with the name specified in the global section |   no     |  False  |
 | **public_ip**              | Boolean flag for wether to use a public IP (**vm only**)                    |   no     |  False  |
 | **resource_tags**          | Tags to be assigned to the resources                                        |   no     |         |

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ This dictionary describes the resources for the project.
 | **os_disk_size**           | OS Disk size in GB. This is only needed if you want to use a non default size or increase the OS disk size|   no     |         |
 | **os_storage_sku**         | OS Storage SKU. `Premium_LRS`, `StandardSSD_LRS` or `Standard_LRS`          |   no     |Premium_LRS|
 | **password**               | user admin password to use with Windows                                     |   no     |         |
+| **cloud_init_sasurl**      | SASURL indicating the location of the cloud-init script                     |   no     |  None   |
 | **proximity_placement_group**| Boolean flag for wether to include the resource in the proximity placement group with the name specified in the global section |   no     |  False  |
 | **public_ip**              | Boolean flag for wether to use a public IP (**vm only**)                    |   no     |  False  |
 | **resource_tags**          | Tags to be assigned to the resources                                        |   no     |         |

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ This dictionary describes the resources for the project.
 | **os_disk_size**           | OS Disk size in GB. This is only needed if you want to use a non default size or increase the OS disk size|   no     |         |
 | **os_storage_sku**         | OS Storage SKU. `Premium_LRS`, `StandardSSD_LRS` or `Standard_LRS`          |   no     |Premium_LRS|
 | **password**               | user admin password to use with Windows                                     |   no     |         |
-| **cloud_init_url**         | URL indicating the location of the cloud-init script                        |   no     |  None   |
+| **custom_data**            | File (@file) or URL indicating the location of the cloud-init script        |   no     |  None   |
 | **proximity_placement_group**| Boolean flag for wether to include the resource in the proximity placement group with the name specified in the global section |   no     |  False  |
 | **public_ip**              | Boolean flag for wether to use a public IP (**vm only**)                    |   no     |  False  |
 | **resource_tags**          | Tags to be assigned to the resources                                        |   no     |         |

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # AzureHPC Change log
 
+- [PR 320](https://github.com/Azure/azurehpc/pull/320) : Support Cloud-Init in vm/vmss
 - [PR 319](https://github.com/Azure/azurehpc/pull/319) : PBS automatic deletion of idle vmss instances
 - [PR 316](https://github.com/Azure/azurehpc/pull/316) : telegraf.conf modified to report interrupts and conntracks
 - [PR 315](https://github.com/Azure/azurehpc/pull/315) : Support macros in azhpc-get

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # AzureHPC Change log
 
-- [PR 320](https://github.com/Azure/azurehpc/pull/320) : Support Cloud-Init in vm/vmss
+- [PR 320](https://github.com/Azure/azurehpc/pull/320) : Support Custom Data (Cloud-Init) in vm/vmss
 - [PR 319](https://github.com/Azure/azurehpc/pull/319) : PBS automatic deletion of idle vmss instances
 - [PR 316](https://github.com/Azure/azurehpc/pull/316) : telegraf.conf modified to report interrupts and conntracks
 - [PR 315](https://github.com/Azure/azurehpc/pull/315) : Support macros in azhpc-get

--- a/examples/bastion/cloud-init.txt
+++ b/examples/bastion/cloud-init.txt
@@ -1,0 +1,11 @@
+#cloud-config
+
+packages:
+ - git
+ - epel-release
+
+runcmd:
+ - [ yum, "-y", install, "jq" ]
+ - [ su, "-c", "git clone https://github.com/Azure/azurehpc.git", "-", hpcadmin ]
+ - [ sh, "-c", "~hpcadmin/azurehpc/scripts/install-azcopy.sh" ]
+ - [ sh, "-c", "~hpcadmin/azurehpc/scripts/install-azcli.sh" ]

--- a/examples/bastion/config_no_pub_ip.json
+++ b/examples/bastion/config_no_pub_ip.json
@@ -15,7 +15,7 @@
         "storage_acc": "<NOT-SET>",
         "vnet_resource_group": "variables.resource_group",
         "jumpbox_pw": "secret.{{variables.key_vault}}.jumpbox_pw",
-        "cloud_init_sasurl": "sasurl.{{variables.storage_acc}}.data/cloud-init.txt"
+        "customdata": "sasurl.{{variables.storage_acc}}.data/cloud-init.txt"
     },
     "vnet": {
         "resource_group": "variables.vnet_resource_group",
@@ -33,7 +33,7 @@
             "public_ip": false,
             "image": "variables.jumpbox_image",
             "accelerated_networking": true,
-            "cloud_init_url": "variables.cloud_init_sasurl",
+            "custom_data": "variables.customdata",
             "subnet": "compute",
             "tags": []
         }
@@ -47,16 +47,6 @@
                 "variables.location",
                 "variables.bastion_subnet"
             ]
-        },
-        {
-            "type": "local_script",
-            "script": "reset_headnode_passwd.sh",
-            "args": [
-            "variables.resource_group",
-            "jumpbox",
-            "hpcuser",
-            "variables.jumpbox_pw"
-          ]
         }
     ]
 }

--- a/examples/bastion/config_no_pub_ip.json
+++ b/examples/bastion/config_no_pub_ip.json
@@ -33,7 +33,7 @@
             "public_ip": false,
             "image": "variables.jumpbox_image",
             "accelerated_networking": true,
-            "cloud_init_sasurl": "variables.cloud_init_sasurl",
+            "cloud_init_url": "variables.cloud_init_sasurl",
             "subnet": "compute",
             "tags": []
         }

--- a/examples/bastion/config_no_pub_ip.json
+++ b/examples/bastion/config_no_pub_ip.json
@@ -4,7 +4,7 @@
     "install_from": "",
     "admin_user": "hpcadmin",
     "variables": {
-        "jumpbox_image": "OpenLogic:CentOS-CI:7-CI:latest",
+        "jumpbox_image": "OpenLogic:CentOS:7.7:latest",
         "location": "southcentralus",
         "resource_group": "<NOT-SET>",
         "vm_type": "Standard_D4s_v3",

--- a/examples/bastion/config_no_pub_ip.json
+++ b/examples/bastion/config_no_pub_ip.json
@@ -4,15 +4,18 @@
     "install_from": "",
     "admin_user": "hpcadmin",
     "variables": {
-        "jumpbox_image": "OpenLogic:CentOS:7.7:latest",
+        "jumpbox_image": "OpenLogic:CentOS-CI:7-CI:latest",
         "location": "southcentralus",
         "resource_group": "<NOT-SET>",
         "vm_type": "Standard_D4s_v3",
         "low_priority": false,
         "bastion_subnet": "<NOT-SET>",
         "rm_vm_name": "jumpbox",
+        "key_vault": "<NOT-SET>",
+        "storage_acc": "<NOT-SET>",
         "vnet_resource_group": "variables.resource_group",
-        "jumpbox_pw": "<NOT-SET>"
+        "jumpbox_pw": "secret.{{variables.key_vault}}.jumpbox_pw",
+        "cloud_init_sasurl": "sasurl.{{variables.storage_acc}}.data/cloud-init.txt"
     },
     "vnet": {
         "resource_group": "variables.vnet_resource_group",
@@ -30,6 +33,7 @@
             "public_ip": false,
             "image": "variables.jumpbox_image",
             "accelerated_networking": true,
+            "cloud_init_sasurl": "variables.cloud_init_sasurl",
             "subnet": "compute",
             "tags": []
         }

--- a/examples/bastion/readme.md
+++ b/examples/bastion/readme.md
@@ -3,7 +3,7 @@
 Visualisation: [config.json](https://azurehpc.azureedge.net/o=https://raw.githubusercontent.com/Azure/azurehpc/master/examples/bastion/config.json)
 
 This example will create an HPC cluster wth no public IP, you can log-in using Azure Bastion, from the Portal RDP to a Windows VM or ssh to a linux VM.
->Note: The config_no_pub_ip.json deploys an Azure Bastion, VNET and a jumpbox (no pub IP), then you can login to the jumpbox via the azure bastion and deploy the rest of your azurehpc deployment. The config_no_pub_ip.json contains an example of using cloud-init in AzureHPC. The AzureHPC prerequisites are installed on the jumpbox (with no public IP) using a cloud-init script (cloud-init.txt (Installs git, jq, AzureHPC git clone, azcopy and azcli). The Cloud-init script needs to be uploaded to blob storage in advance.
+>Note: The config_no_pub_ip.json deploys an Azure Bastion, VNET and a jumpbox (no pub IP), then you can login to the jumpbox via the azure bastion and deploy the rest of your azurehpc deployment. The config_no_pub_ip.json contains an example of using cloud-init in AzureHPC. The AzureHPC prerequisites are installed on the jumpbox (with no public IP) using a cloud-init script (cloud-init.txt (Installs git, jq, AzureHPC git clone, azcopy and azcli). The Cloud-init script needs to be either uploaded to blob storage in advance or referenced in the config file by @cloud-init.txt (read-in directly).
 
 ## Initialise the project
 
@@ -42,7 +42,7 @@ Locate the VM you want to connect to on the Azure portal and check "Connect".
 
 ![Alt text](/examples/bastion/images/bastion_connect.JPG?raw=true "Azure Bastion connect")
 
-Click the bastion option and login using your private keys or user/password
+Click the bastion option and login using your private keys.
 
 ![Alt text2](/examples/bastion/images/bastion_ssh.JPG?raw=true "Azure Bastion ssh")
 

--- a/examples/bastion/readme.md
+++ b/examples/bastion/readme.md
@@ -3,7 +3,7 @@
 Visualisation: [config.json](https://azurehpc.azureedge.net/o=https://raw.githubusercontent.com/Azure/azurehpc/master/examples/bastion/config.json)
 
 This example will create an HPC cluster wth no public IP, you can log-in using Azure Bastion, from the Portal RDP to a Windows VM or ssh to a linux VM.
->Note: The config_no_pub_ip.json deploys an Azure Bastion, VNET and a jumpbox (no pub IP), then you can login to the jumpbox via the azure bastion and deploy the rest of your azurehpc deployment.
+>Note: The config_no_pub_ip.json deploys an Azure Bastion, VNET and a jumpbox (no pub IP), then you can login to the jumpbox via the azure bastion and deploy the rest of your azurehpc deployment. The config_no_pub_ip.json contains an example of using cloud-init in AzureHPC. The AzureHPC prerequisites are installed on the jumpbox (with no public IP) using a cloud-init script (cloud-init.txt (Installs git, jq, AzureHPC git clone, azcopy and azcli). The Cloud-init script needs to be uploaded to blob storage in advance.
 
 ## Initialise the project
 

--- a/pyazhpc/arm.py
+++ b/pyazhpc/arm.py
@@ -445,7 +445,7 @@ class ArmTemplate:
         rmanagedidentity = res.get("managed_identity", None)
         loc = cfg["location"]
         ravset = res.get("availability_set")
-        cloudinit = res.get("cloud_init_sasurl", None)
+        cloudinit = res.get("cloud_init_url", None)
         adminuser = cfg["admin_user"]
         rrg = cfg["resource_group"]
         vnetname = cfg["vnet"]["name"]
@@ -731,7 +731,7 @@ class ArmTemplate:
         rdatadisks = res.get("data_disks", [])
         rstoragesku = res.get("storage_sku", "Premium_LRS")
         rstoragecache = res.get("storage_cache", "ReadWrite")
-        cloudinit = res.get("cloud_init_sasurl", None)
+        cloudinit = res.get("cloud_init_url", None)
         loc = cfg["location"]
         adminuser = cfg["admin_user"]
         rrg = cfg["resource_group"]

--- a/pyazhpc/arm.py
+++ b/pyazhpc/arm.py
@@ -348,7 +348,7 @@ class ArmTemplate:
                 "location": loc
             })
 
-    def __helper_arm_create_osprofile(self, rname, rtype, adminuser, adminpass, sshkey):
+    def __helper_arm_create_osprofile(self, rname, rtype, adminuser, adminpass, sshkey, cloudinit):
         if rtype == "vm":
             name = "computerName"
         else:
@@ -358,6 +358,9 @@ class ArmTemplate:
             name: rname,
             "adminUsername": adminuser
         }
+        if cloudinit:
+           customdata = "#include\n" + cloudinit
+           osprofile["customData"] = "[base64('" + customdata + "')]"
         if adminpass != "<no-password>":
             osprofile["adminPassword"] = adminpass
         else:
@@ -442,6 +445,7 @@ class ArmTemplate:
         rmanagedidentity = res.get("managed_identity", None)
         loc = cfg["location"]
         ravset = res.get("availability_set")
+        cloudinit = res["cloud_init_sasurl"]
         adminuser = cfg["admin_user"]
         rrg = cfg["resource_group"]
         vnetname = cfg["vnet"]["name"]
@@ -604,7 +608,7 @@ class ArmTemplate:
                 "properties": nicprops
             })
 
-            osprofile = self.__helper_arm_create_osprofile(r, rtype, adminuser, rpassword, sshkey)
+            osprofile = self.__helper_arm_create_osprofile(r, rtype, adminuser, rpassword, sshkey, cloudinit)
             datadisks = self.__helper_arm_create_datadisks(rdatadisks, rstoragesku, rstoragecache)
             imageref = self.__helper_arm_create_image_reference(rimage)
 
@@ -727,6 +731,7 @@ class ArmTemplate:
         rdatadisks = res.get("data_disks", [])
         rstoragesku = res.get("storage_sku", "Premium_LRS")
         rstoragecache = res.get("storage_cache", "ReadWrite")
+        cloudinit = res["cloud_init_sasurl"]
         loc = cfg["location"]
         adminuser = cfg["admin_user"]
         rrg = cfg["resource_group"]
@@ -747,7 +752,7 @@ class ArmTemplate:
         if rppg:
             deps.append("Microsoft.Compute/proximityPlacementGroups/"+rppgname)
 
-        osprofile = self.__helper_arm_create_osprofile(r, rtype, adminuser, rpassword, sshkey)
+        osprofile = self.__helper_arm_create_osprofile(r, rtype, adminuser, rpassword, sshkey, cloudinit)
         datadisks = self.__helper_arm_create_datadisks(rdatadisks, rstoragesku, rstoragecache)
         imageref = self.__helper_arm_create_image_reference(rimage)
 

--- a/pyazhpc/arm.py
+++ b/pyazhpc/arm.py
@@ -445,7 +445,7 @@ class ArmTemplate:
         rmanagedidentity = res.get("managed_identity", None)
         loc = cfg["location"]
         ravset = res.get("availability_set")
-        cloudinit = res["cloud_init_sasurl"]
+        cloudinit = res.get("cloud_init_sasurl", None)
         adminuser = cfg["admin_user"]
         rrg = cfg["resource_group"]
         vnetname = cfg["vnet"]["name"]
@@ -731,7 +731,7 @@ class ArmTemplate:
         rdatadisks = res.get("data_disks", [])
         rstoragesku = res.get("storage_sku", "Premium_LRS")
         rstoragecache = res.get("storage_cache", "ReadWrite")
-        cloudinit = res["cloud_init_sasurl"]
+        cloudinit = res.get("cloud_init_sasurl", None)
         loc = cfg["location"]
         adminuser = cfg["admin_user"]
         rrg = cfg["resource_group"]

--- a/pyazhpc/arm.py
+++ b/pyazhpc/arm.py
@@ -348,18 +348,19 @@ class ArmTemplate:
                 "location": loc
             })
 
-    def __helper_arm_create_osprofile(self, rname, rtype, adminuser, adminpass, sshkey, cloudinit):
+    def __helper_arm_create_osprofile(self, rname, rtype, adminuser, adminpass, sshkey, customdata):
         if rtype == "vm":
             name = "computerName"
         else:
             name = "computerNamePrefix"
-        
+         
         osprofile = {
             name: rname,
             "adminUsername": adminuser
         }
-        if cloudinit:
-           customdata = "#include\n" + cloudinit
+        if customdata:
+           if customdata.startswith("http"):
+              customdata = "#include\n" + customdata
            osprofile["customData"] = "[base64('" + customdata + "')]"
         if adminpass != "<no-password>":
             osprofile["adminPassword"] = adminpass
@@ -445,7 +446,7 @@ class ArmTemplate:
         rmanagedidentity = res.get("managed_identity", None)
         loc = cfg["location"]
         ravset = res.get("availability_set")
-        cloudinit = res.get("cloud_init_url", None)
+        customdata = res.get("custom_data", None)
         adminuser = cfg["admin_user"]
         rrg = cfg["resource_group"]
         vnetname = cfg["vnet"]["name"]
@@ -608,7 +609,7 @@ class ArmTemplate:
                 "properties": nicprops
             })
 
-            osprofile = self.__helper_arm_create_osprofile(r, rtype, adminuser, rpassword, sshkey, cloudinit)
+            osprofile = self.__helper_arm_create_osprofile(r, rtype, adminuser, rpassword, sshkey, customdata)
             datadisks = self.__helper_arm_create_datadisks(rdatadisks, rstoragesku, rstoragecache)
             imageref = self.__helper_arm_create_image_reference(rimage)
 
@@ -731,7 +732,7 @@ class ArmTemplate:
         rdatadisks = res.get("data_disks", [])
         rstoragesku = res.get("storage_sku", "Premium_LRS")
         rstoragecache = res.get("storage_cache", "ReadWrite")
-        cloudinit = res.get("cloud_init_url", None)
+        customdata = res.get("custom_data", None)
         loc = cfg["location"]
         adminuser = cfg["admin_user"]
         rrg = cfg["resource_group"]
@@ -752,7 +753,7 @@ class ArmTemplate:
         if rppg:
             deps.append("Microsoft.Compute/proximityPlacementGroups/"+rppgname)
 
-        osprofile = self.__helper_arm_create_osprofile(r, rtype, adminuser, rpassword, sshkey, cloudinit)
+        osprofile = self.__helper_arm_create_osprofile(r, rtype, adminuser, rpassword, sshkey, customdata)
         datadisks = self.__helper_arm_create_datadisks(rdatadisks, rstoragesku, rstoragecache)
         imageref = self.__helper_arm_create_image_reference(rimage)
 

--- a/pyazhpc/azconfig.py
+++ b/pyazhpc/azconfig.py
@@ -51,7 +51,7 @@ class ConfigFile:
             return self.__evaluate_list(input, extended)
         elif type(input) == str:
             fname = self.file_location + "/" + input[1:]
-            if input.startswith("@") and os.path.isfile(fname):
+            if input.startswith("@") and os.path.isfile(fname) and fname.endswith(".json"):
                 log.debug(f"loading include {fname}")
                 with open(fname) as f:
                     input = json.load(f)
@@ -91,7 +91,7 @@ class ConfigFile:
             for x in v.split('.'):
                 if type(it) is str:
                     fname = self.file_location + "/" + it[1:]
-                    if it.startswith("@") and os.path.isfile(fname):
+                    if it.startswith("@") and os.path.isfile(fname) and fname.endswith(".json"):
                         log.debug(f"loading include {fname}")
                         with open(fname) as f:
                             it = json.load(f)
@@ -161,7 +161,14 @@ class ConfigFile:
         elif extended and prefix == "image":
             res = azutil.get_image_id(parts[1], parts[2])
         else:
-            res = v
+            # test to see if we are including a files contents (e.g. for customData)
+            fname = self.file_location + "/" + v[1:]
+            if v.startswith("@") and os.path.isfile(fname):
+                log.debug(f"loading text include {fname}")
+                with open(fname) as f:
+                    res = f.read()
+            else:
+                res = v
         
         log.debug("process_value (exit): "+str(v)+"="+str(res))
         return res


### PR DESCRIPTION
Added support for cloud-init in AzureHPC, primary use case would be install software on no-public IP VM/VMSS
(e.g AzureHPC prerequisites (git, jq, AzureHPC git clone, azcopy and azcli) (see cloud-init.txt example file).

Cloud-init scripts need to be uploaded to blob storage in advance of AzureHPC deployment.

The Cloud-init scripts can be then referenced using "cloud_init_sasurl" key.

e.g "cloud_init_sasurl": "sasurl.{{variables.storage_acc}}.data/cloud-init.txt"

The bastion config_no_pub_ip.json was extended to include cloud-init (Set-up AzureHPC prerequisites on no-pub IP jumpbox).
