### PR TITLE
ND40rs v2 gpu numa mapping

### DIFF
--- a/examples/gpu_numa_mapping/config.json
+++ b/examples/gpu_numa_mapping/config.json
@@ -1,0 +1,129 @@
+{
+  "location": "variables.location",
+  "resource_group": "variables.resource_group",
+  "install_from": "headnode",
+  "admin_user": "hpcadmin",
+  "variables": {
+    "image": "OpenLogic:CentOS-HPC:7.7:latest",
+    "hpc_image": "<NOT-SET>",
+    "location": "<NOT-SET>",
+    "resource_group": "<NOT-SET>",
+    "gpu_vm_type": "Standard_ND40rs_v2",
+    "vm_type": "Standard_D8s_v3",
+    "vnet_resource_group": "variables.resource_group"
+  },
+  "vnet": {
+    "resource_group": "variables.vnet_resource_group",
+    "name": "hpcvnet",
+    "address_prefix": "10.3.0.0/20",
+    "subnets": {
+      "admin": "10.3.1.0/24",
+      "storage": "10.3.3.0/24",
+      "gpu": "10.3.4.0/22"
+    }
+  },
+  "resources": {
+    "headnode": {
+      "type": "vm",
+      "vm_type": "variables.vm_type",
+      "public_ip": true,
+      "image": "variables.image",
+      "data_disks": [2048],
+      "subnet": "compute",
+      "tags": [
+        "cndefault",
+        "nfsserver",
+        "pbsserver",
+        "loginnode",
+        "localuser",
+        "disable-selinux",
+        "azcopy"
+      ]
+    },
+    "gpu": {
+      "type": "vmss",
+      "vm_type": "variables.gpu_vm_type",
+      "instances": 2,
+      "accelerated_networking": false,
+      "low_priority": true,
+      "image": "variables.hpc_image",
+      "subnet": "compute",
+      "tags": [
+        "nfsclient",
+        "pbsclient",
+        "cndefault",
+        "localuser",
+        "disable-selinux",
+        "gpu_numa_mapping"
+      ]
+    }
+  },
+  "install": [
+    {
+      "script": "disable-selinux.sh",
+      "tag": "disable-selinux",
+      "sudo": true
+    },
+    {
+      "script": "cndefault.sh",
+      "tag": "cndefault",
+      "sudo": true
+    },
+    {
+      "script": "nfsserver.sh",
+      "tag": "nfsserver",
+      "sudo": true
+    },
+    {
+      "script": "nfsclient.sh",
+      "args": [
+        "$(<hostlists/tags/nfsserver)"
+      ],
+      "tag": "nfsclient",
+      "sudo": true
+    },
+    {
+      "script": "localuser.sh",
+      "args": [
+        "$(<hostlists/tags/nfsserver)"
+      ],
+      "tag": "localuser",
+      "sudo": true
+    },
+    {
+      "script": "pbsdownload.sh",
+      "tag": "loginnode",
+      "sudo": false
+    },
+    {
+      "script": "pbsserver.sh",
+      "copy": [
+        "pbspro_19.1.1.centos7/pbspro-server-19.1.1-0.x86_64.rpm"
+      ],
+      "tag": "pbsserver",
+      "sudo": true
+    },
+    {
+      "script": "pbsclient.sh",
+      "args": [
+        "$(<hostlists/tags/pbsserver)"
+      ],
+      "copy": [
+        "pbspro_19.1.1.centos7/pbspro-execution-19.1.1-0.x86_64.rpm"
+      ],
+      "tag": "pbsclient",
+      "sudo": true
+    },
+    {
+      "script": "install-azcopy.sh",
+      "tag": "azcopy",
+      "sudo": true
+    },
+    {
+      "script": "gpu_numa_mapping.sh",
+      "tag": "gpu_numa_mapping",
+      "sudo": true,
+      "deps": ["gpu_topo.cpp"]
+    }
+  ]
+}

--- a/examples/gpu_numa_mapping/config.json
+++ b/examples/gpu_numa_mapping/config.json
@@ -33,11 +33,9 @@
       "tags": [
         "cndefault",
         "nfsserver",
-        "pbsserver",
         "loginnode",
         "localuser",
-        "disable-selinux",
-        "azcopy"
+        "disable-selinux"
       ]
     },
     "gpu": {
@@ -50,7 +48,6 @@
       "subnet": "compute",
       "tags": [
         "nfsclient",
-        "pbsclient",
         "cndefault",
         "localuser",
         "disable-selinux",
@@ -88,35 +85,6 @@
         "$(<hostlists/tags/nfsserver)"
       ],
       "tag": "localuser",
-      "sudo": true
-    },
-    {
-      "script": "pbsdownload.sh",
-      "tag": "loginnode",
-      "sudo": false
-    },
-    {
-      "script": "pbsserver.sh",
-      "copy": [
-        "pbspro_19.1.1.centos7/pbspro-server-19.1.1-0.x86_64.rpm"
-      ],
-      "tag": "pbsserver",
-      "sudo": true
-    },
-    {
-      "script": "pbsclient.sh",
-      "args": [
-        "$(<hostlists/tags/pbsserver)"
-      ],
-      "copy": [
-        "pbspro_19.1.1.centos7/pbspro-execution-19.1.1-0.x86_64.rpm"
-      ],
-      "tag": "pbsclient",
-      "sudo": true
-    },
-    {
-      "script": "install-azcopy.sh",
-      "tag": "azcopy",
       "sudo": true
     },
     {

--- a/examples/gpu_numa_mapping/readme.md
+++ b/examples/gpu_numa_mapping/readme.md
@@ -1,4 +1,4 @@
-# Build a PBS ND40rs_v2 GPU cluster with correct GPU mapping
+# Build a ND40rs_v2 GPU cluster with correct GPU mapping
 
 Visualisation: [config.json](https://azurehpc.azureedge.net/?o=https://raw.githubusercontent.com/Azure/azurehpc/master/examples/gpu_numa_mapping/config.json)
 

--- a/examples/gpu_numa_mapping/readme.md
+++ b/examples/gpu_numa_mapping/readme.md
@@ -2,7 +2,7 @@
 
 Visualisation: [config.json](https://azurehpc.azureedge.net/?o=https://raw.githubusercontent.com/Azure/azurehpc/master/examples/gpu_numa_mapping/config.json)
 
-The ND40rs_v2 vm has 8 v100 GPU's. This example sets up a GPU cluster and calculates the correct GPU mapping (including correct mapping of GPU's to host NUMA domains). This uses nvidia-smi for the GPU topology and the cuda bandwidthTest benchmark to determine the correct GPU to numa mapping. The correct GPU mapping is deposited on each GPU in /tmp/gpu_map_file. 
+The ND40rs_v2 vm has 8 v100 GPU's. This example sets up a GPU cluster and calculates the correct GPU mapping (including correct mapping of GPU's to host NUMA domains). This uses nvidia-smi for the GPU topology and the cuda bandwidthTest benchmark to determine the correct GPU to numa mapping. The correct GPU mapping is deposited on each GPU in /tmp/gpu_map_file. A script (bwtest_gpu_map.sh)  to determine the gpu mapping using only cuda bandwidth test is also include (good sanity test). The script bwtest_gpu_map.sh runs a cuda BW test from each GPU to core 0-1 (Numa domain 0), then sorts the BW results and writes the GPU map to /tmp/gpu_map_file, the BW results are also deposited to /tmp/gpu_bwtest_file.
 
 ## Initialise the project
 

--- a/examples/gpu_numa_mapping/readme.md
+++ b/examples/gpu_numa_mapping/readme.md
@@ -1,0 +1,37 @@
+# Build a PBS ND40rs_v2 GPU cluster with correct GPU mapping
+
+Visualisation: [config.json](https://azurehpc.azureedge.net/?o=https://raw.githubusercontent.com/Azure/azurehpc/master/examples/gpu_numa_mapping/config.json)
+
+The ND40rs_v2 vm has 8 v100 GPU's. This example sets up a GPU cluster and calculates the correct GPU mapping (including correct mapping of GPU's to host NUMA domains). This uses nvidia-smi for the GPU topology and the cuda bandwidthTest benchmark to determine the correct GPU to numa mapping. The correct GPU mapping is deposited on each GPU in /tmp/gpu_map_file. 
+
+## Initialise the project
+
+To start you need to copy this directory and update the `config.json`.  Azurehpc provides the `azhpc-init` command that can help here by compying the directory and substituting the unset variables.  First run with the `-s` parameter to see which variables need to be set:
+
+```
+azhpc-init -c $azhpc_dir/examples/gpu_numa_mapping -d gpu_numa_mapping -s
+```
+
+The variables can be set with the `-v` option where variables are comma separated.  The output from the previous command as a starting point.  The `-d` option is required and will create a new directory name for you.  Please update to whatever `resource_group` you would like to deploy to:
+
+```
+azhpc-init -c $azhpc_dir/examples/gpu_numa_mapping -d gpu_numa_mapping -v resource_group=azurehpc-cluster
+```
+
+## Create the cluster 
+
+```
+cd gpu_numa_mapping
+azhpc-build
+```
+
+Allow ~10 minutes for deployment.  You are able to view the status VMs being deployed by running `azhpc-status` in another terminal.
+
+## Log in the cluster
+
+Check the GPU numa_mapping file on each ND40rs_v2 instance.
+
+```
+cat /tmp/gpu_map_file
+3,4,5,6,7,2,1,0
+```

--- a/examples/gpu_numa_mapping/scripts/bwtest_gpu_map.sh
+++ b/examples/gpu_numa_mapping/scripts/bwtest_gpu_map.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+num_gpus=$(lspci | grep NVIDIA | wc -l)
+BWTEST_FILE=/tmp/bwtest_file
+GPU_MAP_FILE=/tmp/gpu_map_file
+START=58798080
+END=67186688
+INCREMENT=4194304
+
+yum install -y cuda-demo-suite-10-1.x86_64
+
+echo
+echo "`date`: Hostname=`hostname`"
+echo "`date`: Found $num_gpus GPUs"
+
+if [  -f $BWTEST_FILE ]; then
+   echo "`date`: Deleting $BWTEST_FILE"
+   rm $BWTEST_FILE
+fi
+if [ -f $GPU_MAP_FILE ]; then
+   echo "`date`: Deleting $GPU_MAP_FILE"
+   rm $GPU_MAP_FILE
+fi
+num_gpu_m1=$((num_gpus-1))
+for gpuid in `seq 0 $num_gpu_m1`
+do
+echo "`date`: Checking GPU: $gpuid"
+bwtest_str=$(taskset -c 0-1 /usr/local/cuda-10.1/extras/demo_suite/bandwidthTest --device=$gpuid  --dtoh --mode=range --start=$START --end=$END --increment=$INCREMENT | grep 62992384 | awk '{print $2}')
+echo "$gpuid $bwtest_str" >> $BWTEST_FILE
+done
+
+sort -r -k 2 -o $BWTEST_FILE $BWTEST_FILE
+
+gpu_array=()
+while read line
+do
+   value=$(echo $line | awk '{print $1}')
+   gpu_array+=($value)
+done < $BWTEST_FILE
+
+gpu_map=$(echo ${gpu_array[@]} | sed 's/ /,/g')
+
+echo
+echo $gpu_map 
+echo $gpu_map > $GPU_MAP_FILE

--- a/examples/gpu_numa_mapping/scripts/bwtest_gpu_map.sh
+++ b/examples/gpu_numa_mapping/scripts/bwtest_gpu_map.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 num_gpus=$(lspci | grep NVIDIA | wc -l)
-BWTEST_FILE=/tmp/bwtest_file
+BWTEST_FILE=/tmp/gpu_bwtest_file
 GPU_MAP_FILE=/tmp/gpu_map_file
 START=58798080
 END=67186688

--- a/examples/gpu_numa_mapping/scripts/gpu_numa_mapping.sh
+++ b/examples/gpu_numa_mapping/scripts/gpu_numa_mapping.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+GPU_MAP_FILE=/tmp/gpu_map_file
+gpu_topo_dir=$DIR
+exe_name=gpu_topo
+START=58798080
+END=62992384
+INCREMENT=4194304
+
+function list_to_array
+{
+OIFS=$IFS
+IFS=","
+array_order=($1)
+IFS=$OIFS
+}
+
+function create_array_groups
+{
+second_group_indx_m1=$((second_group_indx-1))
+num_gpus_m1=$((num_gpus-1))
+array_order_gp1=()
+array_order_gp2=()
+for i in `seq 0 $second_group_indx_m1`
+do
+   array_order_gp1+=(${array_order[$i]}) 
+done
+for i in `seq $second_group_indx $num_gpus_m1`
+do
+   array_order_gp2+=(${array_order[$i]}) 
+done
+}
+
+function swap_array_groups
+{
+   new_array_order=()
+   for indx in ${array_order_gp2[@]}
+   do
+     new_array_order+=($indx)
+   done
+   for indx in ${array_order_gp1[@]}
+   do
+     new_array_order+=($indx)
+   done
+}
+
+yum install -y cuda-demo-suite-10-1.x86_64
+echo
+if [ -f $GPU_MAP_FILE ]; then
+   echo "`date`: Deleting $GPU_MAP_FILE"
+   rm $GPU_MAP_FILE
+fi
+
+if [ ! -f /tmp/topo ]; then
+   nvidia-smi topo -p2p n | grep OK | head -n 8 | awk '{$1=""; print $0}' | sed 's/ //' | tee /tmp/topo
+fi
+
+if [ ! -f $gpu_topo_dir/$exe_name ]; then
+   echo "`date`: Compiling $gpu_topo_dir/$exe_name"
+   g++ -o $gpu_topo_dir/gpu_topo $gpu_topo_dir/gpu_topo.cpp
+fi
+order=$($gpu_topo_dir/$exe_name /tmp/topo)
+echo "`date`: Checking GPU mapping order $order"
+
+list_to_array "$order"
+num_gpus=${#array_order[@]}
+second_group_indx=$((num_gpus/2))
+first_group_gpuid=${array_order[0]}
+second_group_gpuid=${array_order[$second_group_indx]}
+second_group_gpuid=$(echo $second_group_gpuid | awk '{$1=$1;print}')
+
+echo "`date`: Checking GPU ID=$first_group_gpuid"
+bwtest_gpu1=$(taskset -c 0-1 /usr/local/cuda-10.1/extras/demo_suite/bandwidthTest --device=$first_group_gpuid  --dtoh --mode=range --start=$START --end=$END --increment=$INCREMENT | grep 62992384 | awk '{print $2}')
+echo "`date`: GPU $first_group_gpuid BW to numa domain 0 = $bwtest_gpu1 MB/s"
+echo "`date`: Checking GPU ID=$second_group_gpuid"
+bwtest_gpu2=$(taskset -c 0-1 /usr/local/cuda-10.1/extras/demo_suite/bandwidthTest --device=$second_group_gpuid  --dtoh --mode=range --start=$START --end=$END --increment=$INCREMENT | grep 62992384 | awk '{print $2}')
+echo "`date`: GPU $fourth_group_gpuid to numa domain 0 BW= $bwtest_gpu2 MB/s"
+
+if (( $(echo "$bwtest_gpu1 < $bwtest_gpu2"| bc -l) )); then
+   echo "`date`: $bwtest_gpu1 is lt $bwtest_gpu2"
+   echo "`date`: Change GPU mapping to numa domains"
+   create_array_groups
+   swap_array_groups
+   echo "`date`: GPU mapping $(echo ${new_array_order[@]} | sed 's/ /,/g')"
+   echo $(echo ${new_array_order[@]} | sed 's/ /,/g') > $GPU_MAP_FILE
+else
+   echo "`date`: GPU mapping $order"
+   echo $order > $GPU_MAP_FILE
+fi
+echo "`date`: GPU mapping is written to $GPU_MAP_FILE"

--- a/examples/gpu_numa_mapping/scripts/gpu_topo.cpp
+++ b/examples/gpu_numa_mapping/scripts/gpu_topo.cpp
@@ -1,0 +1,94 @@
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <vector>
+using namespace std; 
+
+
+int main(int argc, char *argv[]){
+	if(argc != 2) {
+		cerr  << "Format: gpu_topo topologyMatrixFilePath" << endl;
+		return 2;
+	}
+	char* topoFileName = argv[1];
+	
+	ifstream topoFile(topoFileName);
+	if(!topoFile.is_open()){
+		cerr  << "Topology file: " << topoFileName << " is not readable." << endl;
+		return 2;
+	}
+	vector<vector<string> > topo;
+	string readLine;
+	int m = 0;
+	int n = 0;
+	int n2 = 0;
+	size_t pos = 0;
+	while(getline(topoFile, readLine)){
+		int i = 0;
+		vector<string> readVector;
+		n = n2;
+		n2 = 0;
+		while((pos = readLine.find(" ", i)) != string::npos){
+			readVector.push_back(readLine.substr(i, pos - i));
+			i = pos + 1;
+			n2++;
+		}
+		readVector.push_back(readLine.substr(i, readLine.length() - i));
+		n2++;
+		if(m > 0 && n != n2){
+			cerr  << "Parse the line: " << readLine << " error" << endl;
+			return 2;
+		}
+		topo.push_back(readVector);
+		m++;
+	}
+	topoFile.close();
+	
+	if(m != n){
+		cerr  << "Parse topology file error: " << endl;
+		for(int i = 0; i < m; i++){
+			for(int j = 0; j < m; j++){
+				cerr  << topo[i][j];
+			}
+			cerr  << endl;
+		}
+		return 2;
+	}
+	
+	vector<vector<int> > normTopo(m, vector<int>(n, 0));
+	for(int i = 0; i < m; i++){
+		for(int j = 0; j < n; j++){
+			if(topo[i][j].compare("OK") == 0 || topo[i][j].compare("X") == 0){
+				normTopo[i][j] = 1;
+			}
+		}
+		
+	}
+	
+	vector<int> mark(n, 0);
+	for(int i = 0; i < n; i++){
+		if(normTopo[0][i]){
+			for(int j = 0; j < n; j++){
+				if(normTopo[i][j]){
+					mark[j]++;
+				}
+			}
+		}
+	}
+	
+	vector<int> order;
+	for(int i = 0; i < n; i++){
+		if(mark[i] >= n/2){
+			order.insert(order.begin(), i);
+		}else{
+			order.push_back(i);
+		}
+	}
+	
+	for(int i = 0; i < n; i++){
+		cout << order[i];
+		if(i < n - 1) cout << ", "; 
+	}
+	
+	return 0;
+}


### PR DESCRIPTION
This calculates the correct ND40rs_v2 GPU mapping (topology and mapping to the correct numa domain).

I have complemented some existing scripts by adding a cuda bandwidthTest benchmark to determine the correct GPU mapping to host numa domain (or socket). The mapping file is written to /tmp/gpu_map_file  (e.g 3,4,5,6,7,2,1,0).

I also added a second gpu_mapping script called (bwtest_gpu_map.sh), this scripts used cuda bandwidthtest exclusively to determine the GPU mapping. It does a BW test from each GPU tp core 0-1 (Numa domain 0), then sorts the results and writes the mapping to /tmp/gpu_mapfile and the GPU BW results to /tmp/gpu_bwtest_file (good sanity check).