### PR TITLE
Added support for BeeGFS native client cache

### DIFF
--- a/scripts/beegfsc.sh
+++ b/scripts/beegfsc.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 #
 MGMT_HOSTNAME=$1
+BEEGFS_CACHE=${2:-buffered}
 SHARE_SCRATCH=/beegfs
 
 yum install -y beegfs-client beegfs-helperd beegfs-utils
 
 sed -i 's/^sysMgmtdHost.*/sysMgmtdHost = '$MGMT_HOSTNAME'/g' /etc/beegfs/beegfs-client.conf
+sed -i 's/^tuneFileCacheType.*/tuneFileCacheType = '$BEEGFS_CACHE'/g' /etc/beegfs/beegfs-client.conf
 if [ -d "/usr/src/ofa_kernel/default/include" ]; then
 sed -i 's#^buildArgs=.*#buildArgs=-j8 OFED_INCLUDE_PATH=/usr/src/ofa_kernel/default/include#g' /etc/beegfs/beegfs-client-autobuild.conf
 fi


### PR DESCRIPTION
By default BeeGFS sets the client side caching mode to "buffered" (i.e small pool of resources set aside for caching, managed by BeeGFS).
BeeGFS has a second (classified as experimental) client side caching mode called "native", this mode utilized the linux buffer.

I have added support for the BeeGFS  "native" caching mode. (Leaving buffered as the default.). Added a second optional arg.

I have found with certain I/O patterns (MPIIO with small transfer sizes (32k), that native caching is significantly faster than buffered caching mode.

The blue section in the graph below is using buffered cache mode and the red is the I/O performance using "native" caching mode.

![image](https://user-images.githubusercontent.com/6304999/87835062-b7379200-c851-11ea-8385-8a0a860e831b.png)
