### PR TITLE
Modified the correct location of Make.Linux_AMD_BLIS to BUILD_DIR

### DIFF
--- a/apps/linpack/build_hpl.sh
+++ b/apps/linpack/build_hpl.sh
@@ -18,7 +18,7 @@ build_amd_hpl() {
     export HPL_DIR=$(pwd)
     echo $HPL_DIR
 
-    cp $DIR/Make.Linux_AMD_BLIS .
+    cp $BUILD_DIR/Make.Linux_AMD_BLIS .
     make arch=Linux_AMD_BLIS
     popd
 }

--- a/apps/linpack/build_hpl.sh
+++ b/apps/linpack/build_hpl.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # Prerequisites : OpenMPI 4.0.x + GCC 9.x
 SHARED_APP=${1:-/apps}
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 set -e
 source /etc/profile
 module use /usr/share/Modules/modulefiles


### PR DESCRIPTION
created a branch "fix-linkpack-buildhpl" to fix the build script for building hpl in azurehpc apps.
The current script will work only for PBS, but not in SLURM as the DIR variable sets to be "/apps/linpack" in PBS and while running in SLURM it is "/var/spool/slurmd/job00003"

I made the following line

"cp $DIR/Make.Linux_AMD_BLIS ." to "cp $BUILD_DIR/Make.Linux_AMD_BLIS ."

Without this change - Make file will not be copied in SLURM deployment and hpl will not be built.