### PR TITLE
Corrected storage type options referenced in config.json 

### DIFF
--- a/config.json
+++ b/config.json
@@ -38,7 +38,7 @@
             "ad_username": "User to use to join the domain",
             "joindomain": "Domain name to join to",
             "subnet": "subnet name in which to inject ANF NICs",
-            "type": "anf, azurestorage",
+            "type": "anf, storageaccount",
             "sku": "Standard_LRS, Standard_GRS, Standard_RAGRS, Standard_ZRS, Premium_LRS, Premium_ZRS, Standard_GZRS, Standard_RAGZRS",
             "containers": [ "container1", "container2"],
             "pools": {


### PR DESCRIPTION
Correct config.json referenced in the main README file.
Storage options are anf or storageaccount (not azurestorage).