### PR TITLE
Darshan non-mpi support

### DIFF
--- a/apps/darshan/fio_darshan.pbs
+++ b/apps/darshan/fio_darshan.pbs
@@ -1,0 +1,37 @@
+#!/bin/bash
+FILESYSTEM=${1:-/lustre}
+set -o pipefail
+source /etc/profile
+
+if [ -z "$FILESYSTEM" ]; then
+   echo "Missing Filesystem parameter"
+   exit 1
+fi
+
+SHARED_APPS=/apps
+DIRECTORY=${FILESYSTEM}/testing
+RUNTIME=600
+HOSTNAME=`hostname`
+
+export MODULEPATH=${SHARED_APPS}/modulefiles:$MODULEPATH
+module load gcc-9.2.0
+module load fio
+
+mkdir $DIRECTORY
+NUMJOBS=`cat $PBS_NODEFILE | wc -l`
+
+spack load darshan-runtime~mpi
+DARSHAN_RUNTIME_DIR=$(spack location -i darshan-runtime)
+export LD_PRELOAD=${DARSHAN_RUNTIME_DIR}/lib/libdarshan.so
+export DARSHAN_LOG_DIR_PATH=/share/home/hpcuser/darshan_logs
+mkdir $DARSHAN_LOG_DIR_PATH
+export DARSHAN_ENABLE_NONMPI=1
+
+cd $PBS_O_WORKDIR
+
+BS=4M
+SIZE=5G
+DIRECTIO=1
+RW=write
+
+fio --ioengine=sync --thread --name=${RW}_${SIZE} --directory=$DIRECTORY --direct=$DIRECTIO --size=$SIZE --bs=$BS --rw=${RW} --numjobs=$NUMJOBS --group_reporting --runtime=${RUNTIME} --output=fio_${HOSTNAME}_${RW}_${SIZE}_${BS}_${NUMJOBS}_${DIRECTIO}.out

--- a/apps/darshan/install_darshan_runtime.sh
+++ b/apps/darshan/install_darshan_runtime.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
-
-spack install darshan-runtime+pbs^openmpi@4.0.3%gcc@9.2.0
+if [ "$NON_MPI" == 1 ]; then
+   spack install darshan-runtime+pbs~mpi%gcc@9.2.0
+else
+   spack install darshan-runtime+pbs^openmpi@4.0.3%gcc@9.2.0
+fi

--- a/apps/darshan/install_darshan_util.sh
+++ b/apps/darshan/install_darshan_util.sh
@@ -1,16 +1,18 @@
 #!/bin/bash
 
-spack install darshan-util@gcc@9.2.0
+spack install darshan-util%gcc@9.2.0
 
-sudo yum install xauth
+sudo yum install -y xauth
 
-sudo yum install texlive
-sudo yum install texlive-epstopdf
-sudo yum install gnuplot
-sudo yum install texlive-lastpage
-sudo yum install texlive-subfigure
-sudo yum install texlive-multirow
-sudo yum install texlive-threeparttable
-sudo yum install perl-Pod-LaTeX
-sudo yum install perl-HTML-Parser
-sudo yum install ghostscript
+sudo yum install -y texlive
+sudo yum install -y texlive-epstopdf
+sudo yum install -y gnuplot
+sudo yum install -y texlive-lastpage
+sudo yum install -y texlive-subfigure
+sudo yum install -y texlive-multirow
+sudo yum install -y texlive-threeparttable
+sudo yum install -y perl-Pod-LaTeX
+sudo yum install -y perl-HTML-Parser
+sudo yum install -y ghostscript
+
+sudo yum install -y evince

--- a/apps/darshan/readme.md
+++ b/apps/darshan/readme.md
@@ -37,6 +37,7 @@ On the compute VM's install Darshan-runtime
 ```
 apps/darshan/install_runtime.sh 
 ```
+>Note: Darshan supports mpi and non-mpi codes, to build darshan to profile non-mpi codes (export NON_MPI=1).
 
 ## Example of Running Darshan to I/O profile an IOR benchmark
 
@@ -47,7 +48,7 @@ Run the following IOR PBS script (In this case darshan used LD_PRELOAD to catch 
 qsub -l select=2:ncpus=120:mpiprocs=4 -v FILESYSTEM=/lustre apps/darshan/ior_darshan.pbs
 
 ```
-> Where FILESYSTEM is the location of the filesystem being tested. The environmental variable DARSHAN_LOG_DIR_PATH is the location of the resulting darshan log files. Scripts are provided to create MPI wrappers which will instrument Darshan at compile/link time.
+> Where FILESYSTEM is the location of the filesystem being tested. The environmental variable DARSHAN_LOG_DIR_PATH is the location of the resulting darshan log files. Scripts are provided to create MPI wrappers which will instrument Darshan at compile/link time. Also, see fio_darshan.pbs to see how to get the I/O profile for a non-mpi code.
 
 ## Generate a Darshan graphical summary report.
 


### PR DESCRIPTION
-Added support for non-mpi codes.
-Corrected some errors in darshan-util installation scripts.
-Added non-mpi example PBS script (Generate I/O profile for fio)
-Updated documentation (non-mpi)