### PR TITLE
support and test Gen2 images

### DIFF
--- a/examples/image/pipeline.yml
+++ b/examples/image/pipeline.yml
@@ -28,6 +28,7 @@ variables:
 # Uncomment and set values below, or leave commented and thru pipeline variables
   # azhpc.variables.location: westeurope
   # azhpc.variables.image_name: foo
+  azhpc.variables_matrix: examples/image/test_matrix.json
 
 # <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 

--- a/examples/image/test_matrix.json
+++ b/examples/image/test_matrix.json
@@ -1,0 +1,10 @@
+{
+    "Gen1":
+    {
+        "azhpc.variables.hpc_image": "OpenLogic:CentOS-HPC:7.7:latest"
+    },
+    "Gen2":
+    {
+        "azhpc.variables.image": "OpenLogic:CentOS-HPC:7_7-gen2:latest"
+    }
+}

--- a/examples/nvidia/pipeline.yml
+++ b/examples/nvidia/pipeline.yml
@@ -29,9 +29,9 @@ variables:
 
 # Add the variables needed in your configuration file
 # Uncomment and set values below, or leave commented and thru pipeline variables
-  # azhpc.variables.location: eastus
+  azhpc.variables.location: southcentralus
   #azhpc.variables.vm_type: Standard_NC12s_v3
-  
+  azhpc.variables_matrix: examples/nvidia/test_matrix.json
 # <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 jobs:

--- a/examples/nvidia/test_matrix.json
+++ b/examples/nvidia/test_matrix.json
@@ -1,0 +1,12 @@
+{
+    "Gen1":
+    {
+        "azhpc.variables.vm_type": "Standard_NV12s_v3",
+        "azhpc.variables.image": "OpenLogic:CentOS:7.7:latest"
+    },
+    "Gen2":
+    {
+        "azhpc.variables.vm_type": "Standard_ND40rs_v2",
+        "azhpc.variables.image": "OpenLogic:CentOS:7_7-gen2:latest"
+    }
+}


### PR DESCRIPTION
- when capturing an image automatically detect the hyper-v generation so it doesn't need to be specified in the config file
- added multiple tests for building Gen1 and 2 GPU VMs
- added multiple tests for building and capturing Gen1 & Gen2 images