### PR TITLE
slurmpartition.sh - Improve nodes management

### DIFF
--- a/examples/slurm_autoscale/scripts/slurmpartition.sh
+++ b/examples/slurm_autoscale/scripts/slurmpartition.sh
@@ -76,12 +76,16 @@ for partspec in $partitions_specs; do
   # Remove "Standard_" from the SKU name to use as node feature
   NodeFeature=$(echo $sku | cut -f2,3 -d'_')
 
-  # Calculate max nodes index
-  idx_end=$(printf "%04d" ${instances})
-  
-  echo "NodeName=${partition}-[0001-$idx_end] CPUs=$CPUs Sockets=$Sockets CoresPerSocket=$CoresPerSocket ThreadsPerCore=$ThreadsPerCore RealMemory=$RealMemory MemSpecLimit=$MemSpecLimit Feature=$NodeFeature State=CLOUD" >> /apps/slurm/nodes.conf
-  echo "PartitionName=${partition} Nodes=${partition}-[0001-$idx_end] Default=NO OverSubscribe=YES DefMemPerCPU=$DefMemPerCPU MaxTime=INFINITE State=UP" >> /apps/slurm/partitions.conf
-  
+  # Genrerate nodes indexes range
+  if [[ "$instances" == 'null' ]] || [[ "$instances" == 1 ]]; then
+    node_idxs='0001'
+  else
+    node_idxs=$(printf "[0001-%04d]" ${instances})
+  fi
+
+  echo "NodeName=${partition}-${node_idxs} CPUs=$CPUs Sockets=$Sockets CoresPerSocket=$CoresPerSocket ThreadsPerCore=$ThreadsPerCore RealMemory=$RealMemory MemSpecLimit=$MemSpecLimit Feature=$NodeFeature State=CLOUD" >> /apps/slurm/nodes.conf
+  echo "PartitionName=${partition} Nodes=${partition}-${node_idxs} Default=NO OverSubscribe=YES DefMemPerCPU=$DefMemPerCPU MaxTime=INFINITE State=UP" >> /apps/slurm/partitions.conf
+
 done
 
 systemctl restart slurmctld

--- a/examples/slurm_autoscale/scripts/slurmpartition.sh
+++ b/examples/slurm_autoscale/scripts/slurmpartition.sh
@@ -70,6 +70,9 @@ for partspec in $partitions_specs; do
     CPUs=$numcores
   fi
 
+  # Calculate the actual memory per CPU to use as default memory in partition
+  DefMemPerCPU=$(( (RealMemory - MemSpecLimit) / CPUs ))
+
   # Remove "Standard_" from the SKU name to use as node feature
   NodeFeature=$(echo $sku | cut -f2,3 -d'_')
 
@@ -77,7 +80,7 @@ for partspec in $partitions_specs; do
   idx_end=$(printf "%04d" ${instances})
   
   echo "NodeName=${partition}-[0001-$idx_end] CPUs=$CPUs Sockets=$Sockets CoresPerSocket=$CoresPerSocket ThreadsPerCore=$ThreadsPerCore RealMemory=$RealMemory MemSpecLimit=$MemSpecLimit Feature=$NodeFeature State=CLOUD" >> /apps/slurm/nodes.conf
-  echo "PartitionName=${partition} Nodes=${partition}-[0001-$idx_end] Default=NO OverSubscribe=YES DefMemPerCPU=10240 MaxTime=INFINITE State=UP" >> /apps/slurm/partitions.conf
+  echo "PartitionName=${partition} Nodes=${partition}-[0001-$idx_end] Default=NO OverSubscribe=YES DefMemPerCPU=$DefMemPerCPU MaxTime=INFINITE State=UP" >> /apps/slurm/partitions.conf
   
 done
 


### PR DESCRIPTION
Added logic in `slurmpartition.sh` to correctly handle single instance requests or the case in which `instances` in `config.json` is null.

Assigned exact values of memory per CPU as default memory value per partition. This is possible since each partition contains a single VM SKU.

