### PR TITLE
Intel MLC

### DIFF
--- a/apps/health_checks/install_mlc.sh
+++ b/apps/health_checks/install_mlc.sh
@@ -41,6 +41,7 @@ if [ ! -d $APP_DIR ]; then
 
    cd $APP_DIR
    wget -O $MLC_TAR_GZ $MLC_TAR_GZ_SAS_URL
+   tar xvf $MLC_TAR_GZ
 
-   sudo create_modulefile
+   create_modulefile
 fi

--- a/apps/health_checks/install_mlc.sh
+++ b/apps/health_checks/install_mlc.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+MLC_TAR_GZ_SAS_URL=$1
+SHARED_APP=${2:-/apps}
+APP_NAME=mlc
+MODULE_DIR=${SHARED_APP}/modulefiles
+APP_DIR=$SHARED_APP/$APP_NAME
+
+function get_sas_url_filename() {
+   url_path=${1%\?*}
+   eval $2=$(basename $url_path)
+}
+
+function create_modulefile {
+if [ ! -d ${MODULE_DIR} ]; then
+mkdir -p ${MODULE_DIR}
+cat << EOF >> ${MODULE_DIR}/${APP_NAME}
+#%Module
+set              MLCROOT           ${APP_DIR}
+setenv           MLCROOT           ${APP_DIR}
+
+append-path      PATH              \$MLCROOT/Linux
+EOF
+fi
+}
+
+NR_HUGEPAGES_1GB=$(</sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages)
+NR_HUGEPAGES_2MB=$(</proc/sys/vm/nr_hugepages)
+
+
+if [ $NR_HUGEPAGES_1GB -lt 20 ];then
+   sudo  bash -c "echo 20 > /sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages"
+fi
+if [ $NR_HUGEPAGES_2MB -lt 4000 ];then
+   sudo  bash -c "echo 4000 > /proc/sys/vm/nr_hugepages"
+fi
+
+if [ ! -d $APP_DIR ]; then
+   mkdir -p $APP_DIR
+   get_sas_url_filename $MLC_TAR_GZ_SAS_URL MLC_TAR_GZ
+
+   cd $APP_DIR
+   wget -O $MLC_TAR_GZ $MLC_TAR_GZ_SAS_URL
+
+   sudo create_modulefile
+fi

--- a/apps/health_checks/readme.md
+++ b/apps/health_checks/readme.md
@@ -12,6 +12,22 @@ azhpc-run -n headnode apps/health_checks/install_stream_test.sh
 azhpc-run -n compute /data/node_utils/Stream/stream_test.sh
 ```
 
+### Alternative Intel Memory Latency Checker (MLC) Memory bandwidth test
+Intel MLC is a free intel tool that can be used to measure a VM memory bandwidth, it runs other VM latency tests/checks,
+to see all options passed the --h arg.
+
+To install Intel MLC
+```
+./install_mlc.sh blob_sas_url_full_path_to_mlc_tar.gz
+```
+
+To run all intel MLC memory bandwidth tests
+```
+run_all_mlc_stream.sh /path/to/hostfile
+```
+>Note: You can run Intel MLC on AMD processors also. MLC required hugepages to be enabled. If you do not require
+hugepages you may need to disable them after running the MLC tests.
+
 ### Mellanox clusterkit tests
 Mellanox OFED contains clusterkit (Node and IB healthcheck), its included on CentOS-HPC marketplace images.
 

--- a/apps/health_checks/run_all_mlc_stream.sh
+++ b/apps/health_checks/run_all_mlc_stream.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+HOSTFILE_PATH=$1
+SCRIPT_DIR=${2:-.}
+
+OUTDIR=`date +%Y%m%d_%H%M%S`
+if [ ! -d $OUTDIR ]; then
+   mkdir $OUTDIR
+fi
+
+sudo yum install -y pdsh
+
+HOSTNAME=`hostname`
+
+cd $OUTDIR
+WCOLL=$HOSTFILE_PATH pdsh -f 64 ${SCRIPT_DIR}/mlc --max_bandwidth >& ${HOSTNAME}.out 
+
+grep Stream-triad *.out | sort -n -k 3 2>&1 | tee mlc_stream_report.out

--- a/apps/health_checks/run_mlc_stream.sh
+++ b/apps/health_checks/run_mlc_stream.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+OUTDIR=$1
+
+module use /apps/modulefiles
+module load mlc
+
+HOSTNAME=`hostname`
+
+cd $OUTDIR
+mlc --max_bandwidth >& ${HOSTNAME}.out


### PR DESCRIPTION
- Added installation of Intel MLC
-Use MLC to run memory bandwidth tests and generate a report.