### PR TITLE
Resume install

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,18 +372,19 @@ The new version is now implemneted in Python and it will by default reuse the Py
 
 Aliases have been created to allow an easier usage as well as a backward compatibility with the bash only version :
 
-| Aliases                                   | Description                                                            |
-|-------------------------------------------|------------------------------------------------------------------------|
-| **[azhpc-build](#azhpc-build)**           | Build the resources defined in the config file                         |
-| **[azhpc-connect](#azhpc-connect)**       | This will connect to a node in a running cluster                       |
-| **[azhpc-destroy](#azhpc-destroy)**       | This will delete the resource group defined in the config file         |
-| **[azhpc-get](#azhpc-get)**               | This will return the value of a variable from the config file          |
-| **[azhpc-init](#azhpc-init)**             | Update or create variables in the config file                          |
-| **[azhpc-preprocess](#azhpc-preprocess)** | Preprocess the configuration file                                      |
-| **[azhpc-run](#azhpc-run)**               | Run a command on one of multiple resources                             |
-| **[azhpc-scp](#azhpc-scp)**               | Uses the scp to copy a file to/from the remote resource                |
-| **[azhpc-status](#azhpc-status)**         | Show the uptime for all the resources in the project                   |
-| **[azhpc-watch](#azhpc-watch)**           | This shows the provisioning state of all the resources in the project  |
+| Aliases                                     | Description                                                            |
+|---------------------------------------------|------------------------------------------------------------------------|
+| **[azhpc-build](#azhpc-build)**             | Build the resources defined in the config file                         |
+| **[azhpc-connect](#azhpc-connect)**         | This will connect to a node in a running cluster                       |
+| **[azhpc-destroy](#azhpc-destroy)**         | This will delete the resource group defined in the config file         |
+| **[azhpc-run_install](#azhpc-run_install)** | Just run the install and assume the resource are already there         |
+| **[azhpc-get](#azhpc-get)**                 | This will return the value of a variable from the config file          |
+| **[azhpc-init](#azhpc-init)**               | Update or create variables in the config file                          |
+| **[azhpc-preprocess](#azhpc-preprocess)**   | Preprocess the configuration file                                      |
+| **[azhpc-run](#azhpc-run)**                 | Run a command on one of multiple resources                             |
+| **[azhpc-scp](#azhpc-scp)**                 | Uses the scp to copy a file to/from the remote resource                |
+| **[azhpc-status](#azhpc-status)**           | Show the uptime for all the resources in the project                   |
+| **[azhpc-watch](#azhpc-watch)**             | This shows the provisioning state of all the resources in the project  |
 
 ### azhpc-build
 
@@ -444,6 +445,20 @@ optional arguments:
   --no-color            turn off color in output
   --force               delete resource group immediately
   --no-wait             do not wait for resources to be deleted
+```
+
+### azhpc-run_install
+
+Just run the install and assume the resources are already there.
+
+```
+optional arguments:
+  -h, --help            show this help message and exit
+  --config-file CONFIG_FILE, -c CONFIG_FILE
+                        config file
+  --debug               increase output verbosity
+  --no-color            turn off color in output
+  --step STEP           the install step to start running
 ```
 
 ### azhpc-get

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ if [ -e /etc/centos-release ]; then
     export AZHPC_PYTHONPATH=/usr/lib64/az/lib/python3.6/site-packages
 fi
 
-for cmd in "" build connect destroy get init preprocess run scp status; do
+for cmd in "" build connect destroy run_install get init preprocess run scp status; do
     if [ "$cmd" = "" ]; then
         cmd_name=azhpc
         cmd_launch=azhpc.py

--- a/pyazhpc/azhpc.py
+++ b/pyazhpc/azhpc.py
@@ -702,6 +702,11 @@ def do_run_install(args):
     config = c.preprocess()
 
     tmpdir = "azhpc_install_" + os.path.basename(args.config_file)[:-5]
+    log.debug(f"tmpdir = {tmpdir}")
+    if os.path.isdir(tmpdir):
+        log.debug("removing existing tmp directory")
+        shutil.rmtree(tmpdir)
+    
     adminuser = config["admin_user"]
     private_key_file = adminuser+"_id_rsa"
     public_key_file = adminuser+"_id_rsa.pub"

--- a/pyazhpc/azhpc.py
+++ b/pyazhpc/azhpc.py
@@ -696,6 +696,28 @@ def do_build(args):
             log.info("creating cyclecloud clusters")
             azinstall.generate_cc_clusters(config, f"{tmpdir}/clusters")
 
+def do_run_install(args):
+    c = azconfig.ConfigFile()
+    c.open(args.config_file)
+    config = c.preprocess()
+
+    tmpdir = "azhpc_install_" + os.path.basename(args.config_file)[:-5]
+    adminuser = config["admin_user"]
+    private_key_file = adminuser+"_id_rsa"
+    public_key_file = adminuser+"_id_rsa.pub"
+
+    start_step = args.step
+
+    log.info("building host lists")
+    azinstall.generate_hostlists(config, tmpdir)
+    log.info("building install scripts")
+    azinstall.generate_install(config, tmpdir, adminuser, private_key_file, public_key_file)
+
+    resource_group = c.read_value("resource_group")
+    fqdn = c.get_install_from_destination()
+    log.debug(f"running script from : {fqdn}")
+    azinstall.run(config, tmpdir, adminuser, private_key_file, public_key_file, fqdn, start_step)
+
 def do_destroy(args):
     log.info("reading config file ({})".format(args.config_file))
     config = azconfig.ConfigFile()
@@ -791,6 +813,21 @@ if __name__ == "__main__":
         action="store_true",
         default=False,
         help="do not wait for resources to be deleted"
+    )
+
+    resume_install_parser = subparsers.add_parser(
+        "run_install",
+        parents=[gopt_parser],
+        add_help=False,
+        description="just run the install and assume the resources are already there",
+        help="just run the install and assume the resources are already there"
+    )
+    resume_install_parser.set_defaults(func=do_run_install)
+    resume_install_parser.add_argument(
+        "--step",
+        type=int,
+        help="the install step to start running",
+        default=0
     )
 
     get_parser = subparsers.add_parser(

--- a/pyazhpc/azinstall.py
+++ b/pyazhpc/azinstall.py
@@ -418,15 +418,15 @@ def run(cfg, tmpdir, adminuser, sshprivkey, sshpubkey, fqdn, startstep=0):
         if idx == 0 and not jb:
             continue
 
-        if idx != 0 and idx < startstep:
-            log.info("skipping step")
-            continue
-
         script = step["script"]
         scripttype = step.get("type", "jumpbox_script")
         instcmd = [ f"{tmpdir}/install/{idx:02}_{script}" ]
         log.info(f"Step {idx:02} : {script} ({scripttype})")
         starttime = time.time()
+
+        if idx != 0 and idx < startstep:
+            log.info("    skipping step")
+            continue
 
         if scripttype == "jumpbox_script":
             if jb:

--- a/pyazhpc/azinstall.py
+++ b/pyazhpc/azinstall.py
@@ -407,7 +407,7 @@ def __rsync(sshkey, src, dst):
         log.error("invalid returncode"+_make_subprocess_error_string(res))
         sys.exit(1)
 
-def run(cfg, tmpdir, adminuser, sshprivkey, sshpubkey, fqdn):
+def run(cfg, tmpdir, adminuser, sshprivkey, sshpubkey, fqdn, startstep=0):
     jb = cfg.get("install_from")
     install_steps = [{ "script": "install_node_setup.sh" }] + cfg.get("install", [])
     if jb:
@@ -417,6 +417,11 @@ def run(cfg, tmpdir, adminuser, sshprivkey, sshpubkey, fqdn):
     for idx, step in enumerate(install_steps):
         if idx == 0 and not jb:
             continue
+
+        if idx != 0 and idx < startstep:
+            log.info("skipping step")
+            continue
+
         script = step["script"]
         scripttype = step.get("type", "jumpbox_script")
         instcmd = [ f"{tmpdir}/install/{idx:02}_{script}" ]


### PR DESCRIPTION
This was added for my convenience when debugging my scripts for a config.  If an install fails and you would like to make a change to a script and resume this can be used.  E.g. step 15 fails on the install and so you edit your config and run:

   azhpc run_install --step 15