### PR TITLE
Install steps are now idempotent

### DIFF
--- a/pyazhpc/azinstall.py
+++ b/pyazhpc/azinstall.py
@@ -113,7 +113,9 @@ fi
     if sudo:
         cmdline = "sudo " + cmdline
 
-    content += f"pssh -p {pssh_threads} -t 0 -i -h hostlists/tags/$tag \"cd {tmpdir}; {cmdline}\" >> {logfile} 2>&1\n"
+    marker = f"marker-\"'$(hostname)'\"-{targetscript[:targetscript.rfind('.')]}"
+
+    content += f"pssh -p {pssh_threads} -t 0 -i -h hostlists/tags/$tag \"cd {tmpdir}; test -f {marker} && echo 'script already run' || ( {cmdline} && touch {marker} ) \" >> {logfile} 2>&1\n"
 
     if reboot:
         content += f"""


### PR DESCRIPTION
A marker is created **on each VM** when an install step is completed successfully.  It will only run if the marker is not present.

This has been tested with simple_hpc_pbs and works for scaling up the compute pool (manual steps are required to scale down).

Note: all logs are **appended to**.  This means that the output for previous successful runs will also be shown.  When the marker is detected it is reflected in the output.