### PR TITLE
imb-mpi (hpcx options fix)

### DIFF
--- a/apps/imb-mpi/ringpingpong.sh
+++ b/apps/imb-mpi/ringpingpong.sh
@@ -59,8 +59,7 @@ case $MPI in
         module use /usr/share/Modules/modulefiles
         module load mpi/hpcx
 
-        mpi_options=" --map-by core"
-        mpi_options+=" -bind-to core"
+        mpi_options=" -bind-to core"
         [[ "$ISPBS" = true ]] && mpi_options+=" -npernode 1 -np 2"
         host_option="-host"
 


### PR DESCRIPTION
On CentOS-HPC:7.7:latest

The following hpcx options gives errors (--map-by core)?   (ringpingpong.sh, with ompi option)

[hcvmss000000:44696] PMIX ERROR: NOT-FOUND in file dstore_base.c at line 2866
[hcvmss000000:44696] PMIX ERROR: NOT-FOUND in file server/pmix_server.c at line 3408
[hcvmss000000:44699] PMIX ERROR: OUT-OF-RESOURCE in file client/pmix_client.c at line 231
[hcvmss000000:44699] OPAL ERROR: Error in file pmix3x_client.c at line 112
*** An error occurred in MPI_Init
*** on a NULL communicator
*** MPI_ERRORS_ARE_FATAL (processes in this communicator will now abort,
***    and potentially your MPI job)
