### PR TITLE
Fix for bug #426

### DIFF
--- a/pyazhpc/azinstall.py
+++ b/pyazhpc/azinstall.py
@@ -115,7 +115,7 @@ fi
 
     marker = f"marker-\"'$(hostname)'\"-{step:02}-{targetscript[:targetscript.rfind('.')]}"
 
-    content += f"pssh -p {pssh_threads} -t 0 -i -h hostlists/tags/$tag \"cd {tmpdir}; test -f {marker} && echo 'script already run' || ( {cmdline} && touch {marker} ) \" >> {logfile} 2>&1\n"
+    content += f"pssh -p {pssh_threads} -t 0 -i -h hostlists/tags/$tag \"cd {tmpdir}; test -f {marker} && echo 'script already run' || ( {cmdline} && touch {marker} || true ) \" >> {logfile} 2>&1\n"
 
     if reboot:
         content += f"""


### PR DESCRIPTION
Issue where the failure to create a marker is returned as the command exitcode causing azurehpc to fail.