### PR TITLE
bubble up errors

### DIFF
--- a/pyazhpc/azinstall.py
+++ b/pyazhpc/azinstall.py
@@ -128,7 +128,7 @@ fi
 
     marker = f"marker-\"'$(hostname)'\"-{step:02}-{targetscript[:targetscript.rfind('.')]}"
 
-    content += f"pssh -p {pssh_threads} -t 0 -i -h hostlists/tags/$tag \"cd {tmpdir}; test -f {marker} && echo 'script already run' || ( {cmdline} && touch {marker} || true ) \" >> {logfile} 2>&1\n"
+    content += f"pssh -p {pssh_threads} -t 0 -i -h hostlists/tags/$tag \"cd {tmpdir}; test -f {marker} && echo 'script already run' || ( {cmdline} && ( touch {marker} || true ) ) \" >> {logfile} 2>&1\n"
 
     if reboot:
         content += f"""


### PR DESCRIPTION
fix the breaking change introduced by markers when a script is failing. The error was not bubble up.