### PR TITLE
First support of CentOS 8.1 and OpenPBS 20

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -160,11 +160,11 @@ fi
 
 # Copy Applications run scripts
 echo "Copy Applications run scripts to $AZHPC_SCRIPT_REMOTE_DEST"
-azhpc-scp $debug_option -c $config_file -- -r $BUILD_REPOSITORY_LOCALPATH/apps/. $AZHPC_SCRIPT_REMOTE_DEST || exit 1
+azhpc-scp $debug_option -c $config_file -- -r $BUILD_REPOSITORY_LOCALPATH/apps/* $AZHPC_SCRIPT_REMOTE_DEST || exit 1
 
 # Copy pipeline library scripts
 echo "Copy pipeline library scripts to $AZHPC_SCRIPT_REMOTE_DEST"
-azhpc-scp $debug_option -c $config_file -- -r $BUILD_REPOSITORY_LOCALPATH/ci/scripts/. $AZHPC_SCRIPT_REMOTE_DEST/ci || exit 1
+azhpc-scp $debug_option -c $config_file -- -r $BUILD_REPOSITORY_LOCALPATH/ci/scripts/* $AZHPC_SCRIPT_REMOTE_DEST/ci || exit 1
 
 # List remote files
 echo "List files copied to $AZHPC_SCRIPT_REMOTE_DEST"

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -160,11 +160,11 @@ fi
 
 # Copy Applications run scripts
 echo "Copy Applications run scripts to $AZHPC_SCRIPT_REMOTE_DEST"
-azhpc-scp $debug_option -c $config_file -- -r $BUILD_REPOSITORY_LOCALPATH/apps/* $AZHPC_SCRIPT_REMOTE_DEST || exit 1
+azhpc-scp $debug_option -c $config_file -- -r $BUILD_REPOSITORY_LOCALPATH/apps $AZHPC_SCRIPT_REMOTE_DEST || exit 1
 
 # Copy pipeline library scripts
 echo "Copy pipeline library scripts to $AZHPC_SCRIPT_REMOTE_DEST"
-azhpc-scp $debug_option -c $config_file -- -r $BUILD_REPOSITORY_LOCALPATH/ci/scripts/* $AZHPC_SCRIPT_REMOTE_DEST/ci || exit 1
+azhpc-scp $debug_option -c $config_file -- -r $BUILD_REPOSITORY_LOCALPATH/ci/scripts $AZHPC_SCRIPT_REMOTE_DEST/ci || exit 1
 
 # List remote files
 echo "List files copied to $AZHPC_SCRIPT_REMOTE_DEST"

--- a/examples/anf_full/config.json
+++ b/examples/anf_full/config.json
@@ -110,28 +110,25 @@
             "sudo": true
         },
         {
-            "script": "pbsdownload.sh",
-            "tag": "loginnode",
-            "sudo": false
-        },
-        {
             "script": "pbsserver.sh",
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-server-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsserver",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "pbsclient.sh",
             "args": [
                 "$(<hostlists/tags/pbsserver)"
             ],
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-execution-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsclient",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         }
     ]
 }

--- a/examples/anf_full/config.json
+++ b/examples/anf_full/config.json
@@ -114,8 +114,7 @@
             "tag": "pbsserver",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {
@@ -126,8 +125,7 @@
             "tag": "pbsclient",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         }
     ]

--- a/examples/beegfs/config.json
+++ b/examples/beegfs/config.json
@@ -201,28 +201,25 @@
             "sudo": true
         },
         {
-            "script": "pbsdownload.sh",
-            "tag": "loginnode",
-            "sudo": false
-        },
-        {
             "script": "pbsserver.sh",
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-server-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsserver",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "pbsclient.sh",
             "args": [
                 "$(<hostlists/tags/pbsserver)"
             ],
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-execution-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsclient",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         }
     ]
 }

--- a/examples/beegfs/config.json
+++ b/examples/beegfs/config.json
@@ -40,7 +40,6 @@
                 "cndefault",
                 "nfsserver",
                 "pbsserver",
-                "loginnode",
                 "localuser",
                 "disable-selinux",
                 "beegfspkgs",
@@ -205,8 +204,7 @@
             "tag": "pbsserver",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {
@@ -217,8 +215,7 @@
             "tag": "pbsclient",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         }
     ]

--- a/examples/beegfs_data_disk/config.json
+++ b/examples/beegfs_data_disk/config.json
@@ -39,7 +39,6 @@
                 "cndefault",
                 "nfsserver",
                 "pbsserver",
-                "loginnode",
                 "localuser",
                 "disable-selinux",
                 "beegfspkgs",
@@ -196,8 +195,7 @@
             "tag": "pbsserver",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {
@@ -208,8 +206,7 @@
             "tag": "pbsclient",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         }
     ]

--- a/examples/beegfs_data_disk/config.json
+++ b/examples/beegfs_data_disk/config.json
@@ -192,28 +192,25 @@
             "sudo": true
         },
         {
-            "script": "pbsdownload.sh",
-            "tag": "loginnode",
-            "sudo": false
-        },
-        {
             "script": "pbsserver.sh",
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-server-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsserver",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "pbsclient.sh",
             "args": [
                 "$(<hostlists/tags/pbsserver)"
             ],
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-execution-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsclient",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         }
     ]
 }

--- a/examples/beegfs_local_ssd/config.json
+++ b/examples/beegfs_local_ssd/config.json
@@ -41,7 +41,6 @@
                 "cndefault",
                 "nfsserver",
                 "pbsserver",
-                "loginnode",
                 "localuser",
                 "disable-selinux",
                 "beegfspkgs",
@@ -196,8 +195,7 @@
             "tag": "pbsserver",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {
@@ -208,8 +206,7 @@
             "tag": "pbsclient",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         }
     ]

--- a/examples/beegfs_local_ssd/config.json
+++ b/examples/beegfs_local_ssd/config.json
@@ -192,28 +192,25 @@
             "sudo": true
         },
         {
-            "script": "pbsdownload.sh",
-            "tag": "loginnode",
-            "sudo": false
-        },
-        {
             "script": "pbsserver.sh",
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-server-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsserver",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "pbsclient.sh",
             "args": [
                 "$(<hostlists/tags/pbsserver)"
             ],
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-execution-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsclient",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         }
     ]
 }

--- a/examples/beegfs_pools/config.json
+++ b/examples/beegfs_pools/config.json
@@ -40,7 +40,6 @@
                 "cndefault",
                 "nfsserver",
                 "pbsserver",
-                "loginnode",
                 "localuser",
                 "disable-selinux",
                 "beegfspkgs",
@@ -206,8 +205,7 @@
             "tag": "pbsserver",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {
@@ -218,8 +216,7 @@
             "tag": "pbsclient",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         }
     ]

--- a/examples/beegfs_pools/config.json
+++ b/examples/beegfs_pools/config.json
@@ -202,28 +202,25 @@
             "sudo": true
         },
         {
-            "script": "pbsdownload.sh",
-            "tag": "loginnode",
-            "sudo": false
-        },
-        {
             "script": "pbsserver.sh",
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-server-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsserver",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "pbsclient.sh",
             "args": [
                 "$(<hostlists/tags/pbsserver)"
             ],
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-execution-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsclient",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         }
     ]
 }

--- a/examples/glusterfs_data_disks/config.json
+++ b/examples/glusterfs_data_disks/config.json
@@ -42,7 +42,6 @@
                 "cndefault",
                 "localuser",
                 "pbsserver",
-                "loginnode",
                 "nfsserver",
                 "glusterfs_pkgs",
                 "glusterfs_client"
@@ -179,8 +178,7 @@
             "tag": "pbsserver",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {
@@ -191,8 +189,7 @@
             "tag": "pbsclient",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         }
     ]

--- a/examples/glusterfs_data_disks/config.json
+++ b/examples/glusterfs_data_disks/config.json
@@ -175,28 +175,25 @@
             "sudo": true
         },
         {
-            "script": "pbsdownload.sh",
-            "tag": "loginnode",
-            "sudo": false
-        },
-        {
             "script": "pbsserver.sh",
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-server-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsserver",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "pbsclient.sh",
             "args": [
                 "$(<hostlists/tags/pbsserver)"
             ],
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-execution-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsclient",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         }
     ]
 }

--- a/examples/glusterfs_ephemeral/config.json
+++ b/examples/glusterfs_ephemeral/config.json
@@ -167,28 +167,25 @@
             "sudo": true
         },
         {
-            "script": "pbsdownload.sh",
-            "tag": "loginnode",
-            "sudo": false
-        },
-        {
             "script": "pbsserver.sh",
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-server-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsserver",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "pbsclient.sh",
             "args": [
                 "$(<hostlists/tags/pbsserver)"
             ],
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-execution-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsclient",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         }
     ]
 }

--- a/examples/glusterfs_ephemeral/config.json
+++ b/examples/glusterfs_ephemeral/config.json
@@ -38,7 +38,6 @@
                 "cndefault",
                 "localuser",
                 "pbsserver",
-                "loginnode",
                 "nfsserver",
                 "glusterfs_pkgs",
                 "glusterfs_client"
@@ -171,8 +170,7 @@
             "tag": "pbsserver",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {
@@ -183,8 +181,7 @@
             "tag": "pbsclient",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         }
     ]

--- a/examples/lustre_avset/config.json
+++ b/examples/lustre_avset/config.json
@@ -222,28 +222,25 @@
             "sudo": true
         },
         {
-            "script": "pbsdownload.sh",
-            "tag": "loginnode",
-            "sudo": false
-        },
-        {
             "script": "pbsserver.sh",
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-server-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsserver",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "pbsclient.sh",
             "args": [
                 "$(<hostlists/tags/pbsserver)"
             ],
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-execution-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsclient",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         }
     ]
 }

--- a/examples/lustre_avset/config.json
+++ b/examples/lustre_avset/config.json
@@ -49,7 +49,6 @@
                 "lfsazimport",
                 "localuser",
                 "pbsserver",
-                "loginnode",
                 "nfsserver"
             ]
         },
@@ -226,8 +225,7 @@
             "tag": "pbsserver",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {
@@ -238,8 +236,7 @@
             "tag": "pbsclient",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         }
     ]

--- a/examples/lustre_combined/config.json
+++ b/examples/lustre_combined/config.json
@@ -47,7 +47,6 @@
                 "lfsazimport",
                 "localuser",
                 "pbsserver",
-                "loginnode",
                 "nfsserver"
             ]
         },
@@ -207,8 +206,7 @@
             "tag": "pbsserver",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {
@@ -219,8 +217,7 @@
             "tag": "pbsclient",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         }
     ]

--- a/examples/lustre_combined/config.json
+++ b/examples/lustre_combined/config.json
@@ -203,28 +203,25 @@
             "sudo": true
         },
         {
-            "script": "pbsdownload.sh",
-            "tag": "loginnode",
-            "sudo": false
-        },
-        {
             "script": "pbsserver.sh",
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-server-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsserver",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "pbsclient.sh",
             "args": [
                 "$(<hostlists/tags/pbsserver)"
             ],
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-execution-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsclient",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         }
     ]
 }

--- a/examples/lustre_full/config.json
+++ b/examples/lustre_full/config.json
@@ -239,28 +239,25 @@
             "sudo": true
         },
         {
-            "script": "pbsdownload.sh",
-            "tag": "loginnode",
-            "sudo": false
-        },
-        {
             "script": "pbsserver.sh",
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-server-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsserver",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "pbsclient.sh",
             "args": [
                 "$(<hostlists/tags/pbsserver)"
             ],
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-execution-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsclient",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         }
     ]
 }

--- a/examples/lustre_full/config.json
+++ b/examples/lustre_full/config.json
@@ -45,7 +45,6 @@
                 "lfsazimport",
                 "localuser",
                 "pbsserver",
-                "loginnode",
                 "nfsserver"
             ]
         },
@@ -243,8 +242,7 @@
             "tag": "pbsserver",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {
@@ -255,8 +253,7 @@
             "tag": "pbsclient",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         }
     ]

--- a/examples/lustre_ltop/config.json
+++ b/examples/lustre_ltop/config.json
@@ -39,7 +39,6 @@
                 "lfsazimport",
                 "localuser",
                 "pbsserver",
-                "loginnode",
                 "nfsserver"
             ]
         },
@@ -173,8 +172,7 @@
             "tag": "pbsserver",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {
@@ -185,8 +183,7 @@
             "tag": "pbsclient",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         }
     ]

--- a/examples/lustre_ltop/config.json
+++ b/examples/lustre_ltop/config.json
@@ -169,28 +169,25 @@
             "sudo": true
         },
         {
-            "script": "pbsdownload.sh",
-            "tag": "loginnode",
-            "sudo": false
-        },
-        {
             "script": "pbsserver.sh",
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-server-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsserver",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "pbsclient.sh",
             "args": [
                 "$(<hostlists/tags/pbsserver)"
             ],
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-execution-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsclient",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         }
     ]
 }

--- a/examples/lustre_manageddisk/config.json
+++ b/examples/lustre_manageddisk/config.json
@@ -252,28 +252,25 @@
       "sudo": true
     },
     {
-      "script": "pbsdownload.sh",
-      "tag": "loginnode",
-      "sudo": false
-    },
-    {
       "script": "pbsserver.sh",
-      "copy": [
-        "pbspro_19.1.3.centos_7/pbspro-server-19.1.3-0.x86_64.rpm"
-      ],
       "tag": "pbsserver",
-      "sudo": true
+      "sudo": true,
+      "deps": [
+          "pbsdownload.sh",
+          "azhpc-library.sh"
+      ]
     },
     {
       "script": "pbsclient.sh",
       "args": [
         "$(<hostlists/tags/pbsserver)"
       ],
-      "copy": [
-        "pbspro_19.1.3.centos_7/pbspro-execution-19.1.3-0.x86_64.rpm"
-      ],
       "tag": "pbsclient",
-      "sudo": true
+      "sudo": true,
+      "deps": [
+          "pbsdownload.sh",
+          "azhpc-library.sh"
+      ]
     }
   ]
 }

--- a/examples/lustre_manageddisk/config.json
+++ b/examples/lustre_manageddisk/config.json
@@ -45,7 +45,6 @@
         "lfsazimport",
         "localuser",
         "pbsserver",
-        "loginnode",
         "nfsserver"
       ]
     },
@@ -256,8 +255,7 @@
       "tag": "pbsserver",
       "sudo": true,
       "deps": [
-          "pbsdownload.sh",
-          "azhpc-library.sh"
+          "pbsdownload.sh"
       ]
     },
     {
@@ -268,8 +266,7 @@
       "tag": "pbsclient",
       "sudo": true,
       "deps": [
-          "pbsdownload.sh",
-          "azhpc-library.sh"
+          "pbsdownload.sh"
       ]
     }
   ]

--- a/examples/pbs_cgroup/config.json
+++ b/examples/pbs_cgroup/config.json
@@ -92,28 +92,25 @@
             "sudo": true
         },
         {
-            "script": "pbsdownload.sh",
-            "tag": "loginnode",
-            "sudo": false
-        },
-        {
             "script": "pbsserver.sh",
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-server-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsserver",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "pbsclient.sh",
             "args": [
                 "$(<hostlists/tags/pbsserver)"
             ],
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-execution-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsclient",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "pbs_cgroup.sh",

--- a/examples/pbs_cgroup/config.json
+++ b/examples/pbs_cgroup/config.json
@@ -32,7 +32,6 @@
                 "cndefault",
                 "nfsserver",
                 "pbsserver",
-                "loginnode",
                 "localuser",
                 "disable-selinux",
                 "pbs_cgroup",
@@ -96,8 +95,7 @@
             "tag": "pbsserver",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {
@@ -108,8 +106,7 @@
             "tag": "pbsclient",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {

--- a/examples/pbs_delete_idle_vmss/config.json
+++ b/examples/pbs_delete_idle_vmss/config.json
@@ -110,28 +110,25 @@
       "sudo": true
     },
     {
-      "script": "pbsdownload.sh",
-      "tag": "loginnode",
-      "sudo": false
-    },
-    {
       "script": "pbsserver.sh",
-      "copy": [
-        "pbspro_19.1.3.centos_7/pbspro-server-19.1.3-0.x86_64.rpm"
-      ],
       "tag": "pbsserver",
-      "sudo": true
+      "sudo": true,
+      "deps": [
+          "pbsdownload.sh",
+          "azhpc-library.sh"
+      ]
     },
     {
       "script": "pbsclient.sh",
       "args": [
         "$(<hostlists/tags/pbsserver)"
       ],
-      "copy": [
-        "pbspro_19.1.3.centos_7/pbspro-execution-19.1.3-0.x86_64.rpm"
-      ],
       "tag": "pbsclient",
-      "sudo": true
+      "sudo": true,
+      "deps": [
+          "pbsdownload.sh",
+          "azhpc-library.sh"
+      ]
     },
     {
       "script": "install-azcopy.sh",

--- a/examples/pbs_delete_idle_vmss/config.json
+++ b/examples/pbs_delete_idle_vmss/config.json
@@ -36,7 +36,6 @@
         "cndefault",
         "nfsserver",
         "pbsserver",
-        "loginnode",
         "localuser",
         "disable-selinux",
         "azcopy",
@@ -114,8 +113,7 @@
       "tag": "pbsserver",
       "sudo": true,
       "deps": [
-          "pbsdownload.sh",
-          "azhpc-library.sh"
+          "pbsdownload.sh"
       ]
     },
     {
@@ -126,8 +124,7 @@
       "tag": "pbsclient",
       "sudo": true,
       "deps": [
-          "pbsdownload.sh",
-          "azhpc-library.sh"
+          "pbsdownload.sh"
       ]
     },
     {

--- a/examples/reveal_E2E/config.json
+++ b/examples/reveal_E2E/config.json
@@ -12,7 +12,6 @@
     "beegfs_mount": "/beegfs",
     "beegfs_disk_type": "nvme",
     "beegfs_node_type": "both",
-    "beegfs_node_type": "both",
     "beegfs_pools": "false",
     "beegfs_pools_restart": "false",
     "location": "southcentralus",
@@ -53,7 +52,6 @@
         "cndefault",
         "nfsserver",
         "pbsserver",
-        "loginnode",
         "localuser",
         "disable-selinux",
         "beegfspkgs",
@@ -221,8 +219,7 @@
       "tag": "pbsserver",
       "sudo": true,
       "deps": [
-          "pbsdownload.sh",
-          "azhpc-library.sh"
+          "pbsdownload.sh"
       ]
     },
     {
@@ -233,8 +230,7 @@
       "tag": "pbsclient",
       "sudo": true,
       "deps": [
-          "pbsdownload.sh",
-          "azhpc-library.sh"
+          "pbsdownload.sh"
       ]
     },
     {

--- a/examples/reveal_E2E/config.json
+++ b/examples/reveal_E2E/config.json
@@ -217,28 +217,25 @@
       "sudo": true
     },
     {
-      "script": "pbsdownload.sh",
-      "tag": "loginnode",
-      "sudo": false
-    },
-    {
       "script": "pbsserver.sh",
-      "copy": [
-        "pbspro_19.1.3.centos_7/pbspro-server-19.1.3-0.x86_64.rpm"
-      ],
       "tag": "pbsserver",
-      "sudo": true
+      "sudo": true,
+      "deps": [
+          "pbsdownload.sh",
+          "azhpc-library.sh"
+      ]
     },
     {
       "script": "pbsclient.sh",
       "args": [
         "$(<hostlists/tags/pbsserver)"
       ],
-      "copy": [
-        "pbspro_19.1.3.centos_7/pbspro-execution-19.1.3-0.x86_64.rpm"
-      ],
       "tag": "pbsclient",
-      "sudo": true
+      "sudo": true,
+      "deps": [
+          "pbsdownload.sh",
+          "azhpc-library.sh"
+      ]
     },
     {
       "script": "install_linux_rdp.sh",

--- a/examples/simple_hpc_pbs/config.json
+++ b/examples/simple_hpc_pbs/config.json
@@ -5,6 +5,7 @@
     "admin_user": "hpcadmin",
     "variables": {
         "hpc_image": "OpenLogic:CentOS-HPC:7.7:latest",
+        "pbs_version": "19",
         "location": "<NOT-SET>",
         "resource_group": "<NOT-SET>",
         "vm_type": "<NOT-SET>",
@@ -102,22 +103,21 @@
         {
             "script": "pbsserver.sh",
             "tag": "pbsserver",
+            "args": ["variables.pbs_version"],
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {
             "script": "pbsclient.sh",
             "args": [
-                "$(<hostlists/tags/pbsserver)"
+                "$(<hostlists/tags/pbsserver)", "variables.pbs_version"
             ],
             "tag": "pbsclient",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {

--- a/examples/simple_hpc_pbs/config.json
+++ b/examples/simple_hpc_pbs/config.json
@@ -101,28 +101,25 @@
             "sudo": true
         },
         {
-            "script": "pbsdownload.sh",
-            "tag": "loginnode",
-            "sudo": false
-        },
-        {
             "script": "pbsserver.sh",
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-server-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsserver",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "pbsclient.sh",
             "args": [
                 "$(<hostlists/tags/pbsserver)"
             ],
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-execution-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsclient",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "node_healthchecks.sh",

--- a/examples/simple_hpc_pbs/config.json
+++ b/examples/simple_hpc_pbs/config.json
@@ -34,7 +34,6 @@
                 "cndefault",
                 "nfsserver",
                 "pbsserver",
-                "loginnode",
                 "localuser",
                 "disable-selinux"
             ]

--- a/examples/simple_hpc_pbs/test_matrix.json
+++ b/examples/simple_hpc_pbs/test_matrix.json
@@ -1,14 +1,17 @@
 {
     "CentOS-HPC-77-latest":
     {
-        "azhpc.variables.hpc_image": "OpenLogic:CentOS-HPC:7.7:latest"
+        "azhpc.variables.hpc_image": "OpenLogic:CentOS-HPC:7.7:latest",
+        "azhpc.variables.pbs_version" : "19"
     },
     "CentOS-HPC-81-latest":
     {
-        "azhpc.variables.hpc_image": "OpenLogic:CentOS-HPC:8_1:latest"
+        "azhpc.variables.hpc_image": "OpenLogic:CentOS-HPC:8_1:latest",
+        "azhpc.variables.pbs_version" : "20"
     },
     "CentOS-77-latest":
     {
-        "azhpc.variables.hpc_image": "OpenLogic:CentOS:7.7:latest"
+        "azhpc.variables.hpc_image": "OpenLogic:CentOS:7.7:latest",
+        "azhpc.variables.pbs_version" : "19"
     }
 }

--- a/examples/simple_hpc_pbs/test_matrix.json
+++ b/examples/simple_hpc_pbs/test_matrix.json
@@ -3,6 +3,10 @@
     {
         "azhpc.variables.hpc_image": "OpenLogic:CentOS-HPC:7.7:latest"
     },
+    "CentOS-HPC-81-latest":
+    {
+        "azhpc.variables.hpc_image": "OpenLogic:CentOS-HPC:8_1:latest"
+    },
     "CentOS-77-latest":
     {
         "azhpc.variables.hpc_image": "OpenLogic:CentOS:7.7:latest"

--- a/examples/simple_hpc_pbs_docker/config.json
+++ b/examples/simple_hpc_pbs_docker/config.json
@@ -34,7 +34,6 @@
                 "cndefault",
                 "nfsserver",
                 "pbsserver",
-                "loginnode",
                 "localuser",
                 "disable-selinux"
             ]
@@ -96,8 +95,7 @@
             "tag": "pbsserver",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {
@@ -108,8 +106,7 @@
             "tag": "pbsclient",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {

--- a/examples/simple_hpc_pbs_docker/config.json
+++ b/examples/simple_hpc_pbs_docker/config.json
@@ -92,28 +92,25 @@
             "sudo": true
         },
         {
-            "script": "pbsdownload.sh",
-            "tag": "loginnode",
-            "sudo": false
-        },
-        {
             "script": "pbsserver.sh",
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-server-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsserver",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "pbsclient.sh",
             "args": [
                 "$(<hostlists/tags/pbsserver)"
             ],
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-execution-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsclient",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "docker_setup.sh",

--- a/examples/simple_hpc_pbs_ldap/config.json
+++ b/examples/simple_hpc_pbs_ldap/config.json
@@ -36,7 +36,6 @@
                 "ldapserver",
                 "nfsserver",
                 "pbsserver",
-                "loginnode",
                 "localuser",
                 "disable-selinux"
             ]
@@ -125,8 +124,7 @@
             "tag": "pbsserver",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {
@@ -137,8 +135,7 @@
             "tag": "pbsclient",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {

--- a/examples/simple_hpc_pbs_ldap/config.json
+++ b/examples/simple_hpc_pbs_ldap/config.json
@@ -121,28 +121,25 @@
             "sudo": true
         },
         {
-            "script": "pbsdownload.sh",
-            "tag": "loginnode",
-            "sudo": false
-        },
-        {
             "script": "pbsserver.sh",
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-server-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsserver",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "pbsclient.sh",
             "args": [
                 "$(<hostlists/tags/pbsserver)"
             ],
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-execution-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsclient",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "node_healthchecks.sh",

--- a/examples/simple_hpc_pbs_peer_network/config.json
+++ b/examples/simple_hpc_pbs_peer_network/config.json
@@ -40,7 +40,6 @@
                 "cndefault",
                 "nfsserver",
                 "pbsserver",
-                "loginnode",
                 "localuser",
                 "disable-selinux"
             ]
@@ -100,8 +99,7 @@
             "tag": "pbsserver",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {
@@ -112,8 +110,7 @@
             "tag": "pbsclient",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         }
     ]

--- a/examples/simple_hpc_pbs_peer_network/config.json
+++ b/examples/simple_hpc_pbs_peer_network/config.json
@@ -96,28 +96,25 @@
             "sudo": true
         },
         {
-            "script": "pbsdownload.sh",
-            "tag": "loginnode",
-            "sudo": false
-        },
-        {
             "script": "pbsserver.sh",
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-server-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsserver",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "pbsclient.sh",
             "args": [
                 "$(<hostlists/tags/pbsserver)"
             ],
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-execution-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsclient",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         }
     ]
 }

--- a/examples/simple_hpc_pbs_rgs/config.json
+++ b/examples/simple_hpc_pbs_rgs/config.json
@@ -38,7 +38,6 @@
                 "cndefault",
                 "nfsserver",
                 "pbsserver",
-                "loginnode",
                 "localuser",
                 "disable-selinux"
             ]
@@ -126,8 +125,7 @@
             "tag": "pbsserver",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {
@@ -138,8 +136,7 @@
             "tag": "pbsclient",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         }
     ],

--- a/examples/simple_hpc_pbs_rgs/config.json
+++ b/examples/simple_hpc_pbs_rgs/config.json
@@ -122,28 +122,25 @@
             "sudo": true
         },
         {
-            "script": "pbsdownload.sh",
-            "tag": "loginnode",
-            "sudo": false
-        },
-        {
             "script": "pbsserver.sh",
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-server-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsserver",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "pbsclient.sh",
             "args": [
                 "$(<hostlists/tags/pbsserver)"
             ],
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-execution-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsclient",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         }
     ],
     "post_install": {

--- a/examples/simple_hpc_pbs_singularity/config.json
+++ b/examples/simple_hpc_pbs_singularity/config.json
@@ -34,7 +34,6 @@
                 "cndefault",
                 "nfsserver",
                 "pbsserver",
-                "loginnode",
                 "localuser",
                 "disable-selinux"
             ]
@@ -96,8 +95,7 @@
             "tag": "pbsserver",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {
@@ -108,8 +106,7 @@
             "tag": "pbsclient",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {

--- a/examples/simple_hpc_pbs_singularity/config.json
+++ b/examples/simple_hpc_pbs_singularity/config.json
@@ -92,28 +92,25 @@
             "sudo": true
         },
         {
-            "script": "pbsdownload.sh",
-            "tag": "loginnode",
-            "sudo": false
-        },
-        {
             "script": "pbsserver.sh",
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-server-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsserver",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "pbsclient.sh",
             "args": [
                 "$(<hostlists/tags/pbsserver)"
             ],
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-execution-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsclient",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "singularity_setup.sh",

--- a/examples/simple_hpc_pbs_tgx/config.json
+++ b/examples/simple_hpc_pbs_tgx/config.json
@@ -121,28 +121,25 @@
             "sudo": true
         },
         {
-            "script": "pbsdownload.sh",
-            "tag": "loginnode",
-            "sudo": false
-        },
-        {
             "script": "pbsserver.sh",
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-server-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsserver",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "pbsclient.sh",
             "args": [
                 "$(<hostlists/tags/pbsserver)"
             ],
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-execution-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsclient",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         }
     ],
     "post_install": {

--- a/examples/simple_hpc_pbs_tgx/config.json
+++ b/examples/simple_hpc_pbs_tgx/config.json
@@ -37,7 +37,6 @@
                 "cndefault",
                 "nfsserver",
                 "pbsserver",
-                "loginnode",
                 "localuser",
                 "disable-selinux"
             ]
@@ -125,8 +124,7 @@
             "tag": "pbsserver",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {
@@ -137,8 +135,7 @@
             "tag": "pbsclient",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         }
     ],

--- a/examples/simple_hpc_pbs_vpn/config.json
+++ b/examples/simple_hpc_pbs_vpn/config.json
@@ -42,7 +42,6 @@
                 "cndefault",
                 "nfsserver",
                 "pbsserver",
-                "loginnode",
                 "localuser",
                 "disable-selinux",
                 "vpn_client"
@@ -103,8 +102,7 @@
             "tag": "pbsserver",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {
@@ -115,8 +113,7 @@
             "tag": "pbsclient",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {

--- a/examples/simple_hpc_pbs_vpn/config.json
+++ b/examples/simple_hpc_pbs_vpn/config.json
@@ -99,28 +99,25 @@
             "sudo": true
         },
         {
-            "script": "pbsdownload.sh",
-            "tag": "loginnode",
-            "sudo": false
-        },
-        {
             "script": "pbsserver.sh",
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-server-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsserver",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "pbsclient.sh",
             "args": [
                 "$(<hostlists/tags/pbsserver)"
             ],
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-execution-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsclient",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "setup_vpn_client.sh",

--- a/examples/simple_hpc_pbs_zfs/config.json
+++ b/examples/simple_hpc_pbs_zfs/config.json
@@ -34,7 +34,6 @@
                 "cndefault",
                 "nfsserver",
                 "pbsserver",
-                "loginnode",
                 "localuser",
                 "disable-selinux"
             ]
@@ -104,8 +103,7 @@
             "tag": "pbsserver",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {
@@ -116,8 +114,7 @@
             "tag": "pbsclient",
             "sudo": true,
             "deps": [
-                "pbsdownload.sh",
-                "azhpc-library.sh"
+                "pbsdownload.sh"
             ]
         },
         {

--- a/examples/simple_hpc_pbs_zfs/config.json
+++ b/examples/simple_hpc_pbs_zfs/config.json
@@ -100,28 +100,25 @@
             "sudo": true
         },
         {
-            "script": "pbsdownload.sh",
-            "tag": "loginnode",
-            "sudo": false
-        },
-        {
             "script": "pbsserver.sh",
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-server-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsserver",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "pbsclient.sh",
             "args": [
                 "$(<hostlists/tags/pbsserver)"
             ],
-            "copy": [
-                "pbspro_19.1.3.centos_7/pbspro-execution-19.1.3-0.x86_64.rpm"
-            ],
             "tag": "pbsclient",
-            "sudo": true
+            "sudo": true,
+            "deps": [
+                "pbsdownload.sh",
+                "azhpc-library.sh"
+            ]
         },
         {
             "script": "node_healthchecks.sh",

--- a/pyazhpc/azinstall.py
+++ b/pyazhpc/azinstall.py
@@ -289,6 +289,8 @@ def generate_install(cfg, tmpdir, adminuser, sshprivkey, sshpubkey):
     inst = cfg.get("install", [])
     create_jumpbox_setup_script(tmpdir, sshprivkey, sshpubkey)
 
+    # Add library script to the destination
+    __copy_script("azhpc-library.sh", f"{tmpdir}/scripts")
     for n, step in enumerate(inst):
         stype = step.get("type", "jumpbox_script")
         if stype == "jumpbox_script":

--- a/scripts/azhpc-library.sh
+++ b/scripts/azhpc-library.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Library of functions to be used across scripts
+
+is_centos8()
+{
+    read_os
+    if [ "$os_release" == "centos" ] && [ "$os_maj_ver" == "8" ]; then
+        return 1
+    else
+        return 0
+    fi
+}
+
+is_centos7()
+{
+    read_os
+    if [ "$os_release" == "centos" ] && [ "$os_maj_ver" == "7" ]; then
+        return 1 
+    else
+        return 0
+    fi
+}
+
+read_os()
+{
+    os_release=$(cat /etc/os-release | grep "^ID\=" | cut -d'=' -f 2 | sed -e 's/^"//' -e 's/"$//')
+    os_maj_ver=$(cat /etc/os-release | grep "^VERSION_ID\=" | cut -d'=' -f 2 | sed -e 's/^"//' -e 's/"$//')
+    full_version=$(cat /etc/$os_release-release | cut -d' ' -f4)
+}
+
+function fail {
+  echo $1 >&2
+  exit 1
+}
+
+function retry {
+  local n=1
+  local max=5
+  local delay=10
+  while true; do
+    "$@" && break || {
+      if [[ $n -lt $max ]]; then
+        ((n++))
+        echo "Command failed. Attempt $n/$max:"
+        sleep $delay;
+      else
+        fail "The command has failed after $n attempts."
+      fi
+    }
+  done
+}

--- a/scripts/azhpc-library.sh
+++ b/scripts/azhpc-library.sh
@@ -5,9 +5,9 @@ is_centos8()
 {
     read_os
     if [ "$os_release" == "centos" ] && [ "$os_maj_ver" == "8" ]; then
-        return 1
-    else
         return 0
+    else
+        return 1
     fi
 }
 
@@ -15,9 +15,9 @@ is_centos7()
 {
     read_os
     if [ "$os_release" == "centos" ] && [ "$os_maj_ver" == "7" ]; then
-        return 1 
+        return 0 
     else
-        return 0
+        return 1
     fi
 }
 

--- a/scripts/install-nfsserver.sh
+++ b/scripts/install-nfsserver.sh
@@ -72,14 +72,15 @@ exportfs
 ########################################
 # Tune NFS
 ########################################
-if is_centos7; then
-    cores=$(grep processor /proc/cpuinfo | wc -l)
-    nfs_proc=$(($cores * 4))
-    replace="s/#RPCNFSDCOUNT=16/RPCNFSDCOUNT=$nfs_proc/g"
-    sed -i -e "$replace" /etc/sysconfig/nfs
-    grep RPCNFSDCOUNT /etc/sysconfig/nfs
-fi
+
+cores=$(grep processor /proc/cpuinfo | wc -l)
+nfs_proc=$(($cores * 4))
+replace="s/# threads=8/threads=$nfs_proc/g"
+sed -i -e "$replace" /etc/nfs.conf
 
 systemctl restart nfs-server
+
+# Dump the NFSD stats
+cat /proc/net/rpc/nfsd
 
 df -h

--- a/scripts/install-nfsserver.sh
+++ b/scripts/install-nfsserver.sh
@@ -5,8 +5,22 @@ if [[ $(id -u) -ne 0 ]] ; then
     exit 1
 fi
 
+set -e
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$script_dir/azhpc-library.sh" 
+read_os
+
 yum -y install epel-release
-yum -y install nfs-utils nfs-utils-lib
+
+case "$os_maj_ver" in
+    7)
+        yum_list="nfs-utils nfs-utils-lib"
+    ;;
+    8)
+        yum_list="nfs-utils"
+    ;;
+esac
+yum -y install $yum_list
 
 # Shares
 NFS_APPS=$NFS_MOUNT_POINT/apps
@@ -16,15 +30,19 @@ NFS_SCRATCH=/mnt/resource/scratch
 
 systemctl enable rpcbind
 systemctl enable nfs-server
-systemctl enable nfs-lock
-systemctl enable nfs-idmap
-systemctl enable nfs
+if is_centos7; then
+    systemctl enable nfs-lock
+    systemctl enable nfs-idmap
+    systemctl enable nfs
+fi
 
 systemctl start rpcbind
 systemctl start nfs-server
-systemctl start nfs-lock
-systemctl start nfs-idmap
-systemctl start nfs
+if is_centos7; then
+    systemctl start nfs-lock
+    systemctl start nfs-idmap
+    systemctl start nfs
+fi
 
 ######################################
 # Create shares and exports
@@ -54,11 +72,13 @@ exportfs
 ########################################
 # Tune NFS
 ########################################
-cores=$(grep processor /proc/cpuinfo | wc -l)
-nfs_proc=$(($cores * 4))
-replace="s/#RPCNFSDCOUNT=16/RPCNFSDCOUNT=$nfs_proc/g"
-sed -i -e "$replace" /etc/sysconfig/nfs
-grep RPCNFSDCOUNT /etc/sysconfig/nfs
+if is_centos7; then
+    cores=$(grep processor /proc/cpuinfo | wc -l)
+    nfs_proc=$(($cores * 4))
+    replace="s/#RPCNFSDCOUNT=16/RPCNFSDCOUNT=$nfs_proc/g"
+    sed -i -e "$replace" /etc/sysconfig/nfs
+    grep RPCNFSDCOUNT /etc/sysconfig/nfs
+fi
 
 systemctl restart nfs-server
 

--- a/scripts/pbsclient.sh
+++ b/scripts/pbsclient.sh
@@ -2,37 +2,34 @@
 # arg: $1 = pbs_server
 pbs_server=$1
 
-function fail {
-  echo $1 >&2
-  exit 1
-}
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$script_dir/azhpc-library.sh"
 
-function retry {
-  local n=1
-  local max=3
-  local delay=10
-  while true; do
-    "$@" && break || {
-      if [[ $n -lt $max ]]; then
-        ((n++))
-        echo "Command failed. Attempt $n/$max:"
-        sleep $delay;
-      else
-        fail "The command has failed after $n attempts."
-      fi
-    }
-  done
-}
+$script_dir/pbsdownload.sh
 
-if ! rpm -q pbspro-execution; then
+read_os
+case "$os_maj_ver" in
+    7)
+        rpm_list="pbspro_19.1.3.centos_7/pbspro-execution-19.1.3-0.x86_64.rpm"
+        rpm="pbspro-execution"
+        SERVER_NAME_SUBST="CHANGE_THIS_TO_PBS_PRO_SERVER_HOSTNAME"
+    ;;
+    8)
+        rpm_list="openpbs_20.0.1.centos_8/openpbs-execution-20.0.1-0.x86_64.rpm"
+        rpm="openpbs-execution"
+        SERVER_NAME_SUBST="CHANGE_THIS_TO_PBS_SERVER_HOSTNAME"
+    ;;
+esac
+
+if ! rpm -q $rpm; then
     if ! rpm -q jq; then
         yum install -y jq
     fi
 
-    yum install -y pbspro-execution-19.1.3-0.x86_64.rpm
+    yum install -y $rpm_list
 
-    sed -i "s/CHANGE_THIS_TO_PBS_PRO_SERVER_HOSTNAME/${pbs_server}/g" /etc/pbs.conf
-    sed -i "s/CHANGE_THIS_TO_PBS_PRO_SERVER_HOSTNAME/${pbs_server}/g" /var/spool/pbs/mom_priv/config
+    sed -i "s/${SERVER_NAME_SUBST}/${pbs_server}/g" /etc/pbs.conf
+    sed -i "s/${SERVER_NAME_SUBST}/${pbs_server}/g" /var/spool/pbs/mom_priv/config
     sed -i "s/^if /#if /g" /opt/pbs/lib/init.d/limits.pbs_mom
     sed -i "s/^fi/#fi /g" /opt/pbs/lib/init.d/limits.pbs_mom
     systemctl enable pbs

--- a/scripts/pbsclient.sh
+++ b/scripts/pbsclient.sh
@@ -1,24 +1,28 @@
 #!/bin/bash
 # arg: $1 = pbs_server
 pbs_server=$1
+version=${2-19}
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source "$script_dir/azhpc-library.sh"
+source "$script_dir/azhpc-library.sh" # Needed to use the retry function
+$script_dir/pbsdownload.sh $version
 
-$script_dir/pbsdownload.sh
-
-read_os
-case "$os_maj_ver" in
-    7)
+case "$version" in
+    19)
         rpm_list="pbspro_19.1.3.centos_7/pbspro-execution-19.1.3-0.x86_64.rpm"
         rpm="pbspro-execution"
         SERVER_NAME_SUBST="CHANGE_THIS_TO_PBS_PRO_SERVER_HOSTNAME"
     ;;
-    8)
+    20)
         rpm_list="openpbs_20.0.1.centos_8/openpbs-execution-20.0.1-0.x86_64.rpm"
         rpm="openpbs-execution"
         SERVER_NAME_SUBST="CHANGE_THIS_TO_PBS_SERVER_HOSTNAME"
     ;;
+    *)
+        echo "Unknown version $version provided"
+        echo "Usage : $0 <pbs_server> {19|20}"
+        exit 1
+    ;;    
 esac
 
 if ! rpm -q $rpm; then

--- a/scripts/pbsdownload.sh
+++ b/scripts/pbsdownload.sh
@@ -1,9 +1,21 @@
 #!/bin/bash
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$script_dir/azhpc-library.sh"
 
-filename=pbspro_19.1.3.centos_7.zip
+read_os
+case "$os_maj_ver" in
+    7)
+        filename=pbspro_19.1.3.centos_7.zip
+        url=https://github.com/PBSPro/pbspro/releases/download/v19.1.3/$filename
+    ;;
+    8)
+        filename=openpbs_20.0.1.centos_8.zip
+        url=https://github.com/openpbs/openpbs/releases/download/v20.0.1/$filename
+    ;;
+esac
 
 if [ ! -f "$filename" ];then
-    wget -q https://github.com/PBSPro/pbspro/releases/download/v19.1.3/$filename
+    wget -q $url
     unzip $filename
 fi
 

--- a/scripts/pbsdownload.sh
+++ b/scripts/pbsdownload.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
-script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source "$script_dir/azhpc-library.sh"
+version=${1-19}
 
-read_os
-case "$os_maj_ver" in
-    7)
+case "$version" in
+    19)
         filename=pbspro_19.1.3.centos_7.zip
-        url=https://github.com/PBSPro/pbspro/releases/download/v19.1.3/$filename
+        url=https://github.com/openpbs/openpbs/releases/download/v19.1.3/$filename
     ;;
-    8)
+    20)
         filename=openpbs_20.0.1.centos_8.zip
         url=https://github.com/openpbs/openpbs/releases/download/v20.0.1/$filename
+    ;;
+    *)
+        echo "Unknown version $version provided"
+        echo "Usage : $0 {19|20}"
+        exit 1
     ;;
 esac
 

--- a/scripts/pbsserver.sh
+++ b/scripts/pbsserver.sh
@@ -23,10 +23,10 @@ if [ "$(rpm -qa $rpm)" = "" ];then
     yum install -y $rpm_list
     systemctl enable pbs
     systemctl start pbs
-    /opt/pbs/bin/qmgr -c "s s managers += ${admin_user}@*"
-    /opt/pbs/bin/qmgr -c 's s flatuid=t'
-    /opt/pbs/bin/qmgr -c 's s job_history_enable=t'
-    /opt/pbs/bin/qmgr -c 'c r pool_name type=string,flag=h'
+    retry /opt/pbs/bin/qmgr -c "s s managers += ${admin_user}@*"
+    retry /opt/pbs/bin/qmgr -c 's s flatuid=t'
+    retry /opt/pbs/bin/qmgr -c 's s job_history_enable=t'
+    retry /opt/pbs/bin/qmgr -c 'c r pool_name type=string,flag=h'
 
     # Update the sched_config file to schedule jobs that request pool_name
     sed -i "s/^resources: \"ncpus,/resources: \"ncpus, pool_name,/g" /var/spool/pbs/sched_priv/sched_config

--- a/scripts/pbsserver.sh
+++ b/scripts/pbsserver.sh
@@ -1,10 +1,26 @@
 #!/bin/bash
 set -e
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$script_dir/azhpc-library.sh"
+
+$script_dir/pbsdownload.sh
+
+read_os
+case "$os_maj_ver" in
+    7)
+        rpm_list="pbspro_19.1.3.centos_7/pbspro-server-19.1.3-0.x86_64.rpm"
+        rpm="pbspro-server"
+    ;;
+    8)
+        rpm_list="openpbs_20.0.1.centos_8/openpbs-server-20.0.1-0.x86_64.rpm"
+        rpm="openpbs-server"
+    ;;
+esac
 
 admin_user=$(whoami)
 
-if [ "$(rpm -qa pbspro-server)" = "" ];then
-    yum install -y pbspro-server-19.1.3-0.x86_64.rpm
+if [ "$(rpm -qa $rpm)" = "" ];then
+    yum install -y $rpm_list
     systemctl enable pbs
     systemctl start pbs
     /opt/pbs/bin/qmgr -c "s s managers += ${admin_user}@*"

--- a/scripts/pbsserver.sh
+++ b/scripts/pbsserver.sh
@@ -1,20 +1,24 @@
 #!/bin/bash
+version=${1-19}
 set -e
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source "$script_dir/azhpc-library.sh"
+source "$script_dir/azhpc-library.sh" # Needed to use the retry function
+$script_dir/pbsdownload.sh $version
 
-$script_dir/pbsdownload.sh
-
-read_os
-case "$os_maj_ver" in
-    7)
+case "$version" in
+    19)
         rpm_list="pbspro_19.1.3.centos_7/pbspro-server-19.1.3-0.x86_64.rpm"
         rpm="pbspro-server"
     ;;
-    8)
+    20)
         rpm_list="openpbs_20.0.1.centos_8/openpbs-server-20.0.1-0.x86_64.rpm"
         rpm="openpbs-server"
     ;;
+    *)
+        echo "Unknown version $version provided"
+        echo "Usage : $0 {19|20}"
+        exit 1
+    ;;    
 esac
 
 admin_user=$(whoami)


### PR DESCRIPTION
Basic support of CentsOS 8.1 HPC Image in the **simple_hpc_pbs** example
- added pipeline test for CentOS 8.1 HPC Image
- added support of OpenPBS 20
- simplified PBS install scripts. New parameter introduced to specify the version (19 or 20) with 19 being the default
- added script dependency to pbsdownload.sh for pbsclient.sh and pbsserver.sh
- removed all copy operations from config files for PBS clusters
- removed all hardcoded RPM versions from config files for PBS clusters
- added new azhpc variable for PBS version in the **simple_hpc_pbs** example
- added scripts/azhpc-library.sh which contains help functions to retrieve os version and do a retry on commands
- pbsclient.sh and pbsserver.sh are using the retry function defined in azhpc-library.sh
- install-nfsserver.sh updated to support CentOS 7.x and CentOS 8.x

Closing #425 and #466 