### PR TITLE
Build lustre 2.12.6 client on new CentOS-HPC image

### DIFF
--- a/experimental/lustre_2.12.6_client_for_centos_hpc_78/build_lustre_2.12.6_client_centOS_hpc_78.sh
+++ b/experimental/lustre_2.12.6_client_for_centos_hpc_78/build_lustre_2.12.6_client_centOS_hpc_78.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# arg: $1 = lfsserver
+# arg: $2 = mount point (default: /lustre)
+master=$1
+lfs_mount=${2:-/lustre}
+
+BUILD_PATH=/tmp
+LUSTRE_RELEASE=f710782
+LUSTRE_PATCH_NUMBER=41152
+MLNX_OFED_DOWNLOAD_URL=https://azhpcstor.blob.core.windows.net/azhpc-images-store/MLNX_OFED_LINUX-5.2-1.0.4.0-rhel7.8-x86_64.tgz
+
+MLNX_TARBALL=$(basename ${MLNX_OFED_DOWNLOAD_URL})
+MOFED_FOLDER=$(basename ${MLNX_OFED_DOWNLOAD_URL} .tgz)
+
+cd $BUILD_PATH
+wget -O  $MLNX_TARBALL $MLNX_OFED_DOWNLOAD_URL
+tar xvf $MLNX_TARBALL
+
+mkdir $LUSTRE_RELEASE
+cd $LUSTRE_RELEASE
+wget -O ${LUSTRE_RELEASE}.tar.gz https://review.whamcloud.com/changes/${LUSTRE_PATCH_NUMBER}/revisions/f710782156ec21a8a69d7f12a9e7de1bde02c22b/archive?format=tgz
+tar xvf ${LUSTRE_RELEASE}.tar.gz
+
+chmod 777 ./autogen.sh
+./autogen.sh
+
+yum install -y libselinux-devel
+
+./configure
+make
+make rpms
+
+
+yum install ${BUILD_PATH}/${MOFED_FOLDER}/RPMS/kmod-mlnx-ofa_kernel-5.2-OFED.5.2.1.0.4.1.rhel7u8.x86_64.rpm
+
+rpm -ivh ${BUILD_PATH}/${LUSTRE_RELEASE}/kmod-lustre-client-2.12.6-1.el7.x86_64.rpm
+rpm -ivh ${BUILD_PATH}/${LUSTRE_RELEASE}/lustre-client-2.12.6-1.el7.x86_64.rpm
+
+weak-modules --add-kernel $(uname -r)
+
+mkdir $lfs_mount
+echo "${master}@tcp0:/LustreFS $lfs_mount lustre flock,defaults,_netdev 0 0" >> /etc/fstab
+mount -a
+chmod 777 $lfs_mount

--- a/experimental/lustre_2.12.6_client_for_centos_hpc_78/readme.md
+++ b/experimental/lustre_2.12.6_client_for_centos_hpc_78/readme.md
@@ -1,0 +1,23 @@
+## Build lustre 2.12.6 client for CentOS-HPC 7.8 image (withy MOFED 5.2.x)
+
+You will get the following error it you attempt to build the official latest lustre 2.12.6 client on the new CentOS-HPC 7.8 image
+```
+Building for 3.10.0-1127.19.1.el7.x86_64
+Building initial module for 3.10.0-1127.19.1.el7.x86_64
+configure: error: no OFED nor kernel OpenIB gen2 headers present
+Error! Bad return status for module build on kernel: 3.10.0-1127.19.1.el7.x86_64 (x86_64)
+Consult /var/lib/dkms/lustre-client/2.12.6/build/make.log for more information.
+warning: %post(lustre-client-dkms-2.12.6-1.el7.noarch) scriptlet failed, exit status 10
+
+  Installing : lustre-client-dkms-2.12.6-1.el7.noarch                      7/12
+Loading new lustre-client-2.12.6 DKMS files...
+Building for 3.10.0-1127.19.1.el7.x86_64
+Building initial module for 3.10.0-1127.19.1.el7.x86_64
+configure: error: no OFED nor kernel OpenIB gen2 headers present
+Error! Bad return status for module build on kernel: 3.10.0-1127.19.1.el7.x86_64 (x86_64)
+Consult /var/lib/dkms/lustre-client/2.12.6/build/make.log for more information.
+warning: %post(lustre-client-dkms-2.12.6-1.el7.noarch) scriptlet failed, exit status 10
+```
+These error are due to upgrading the MOFED grom 5.1.x to 5.2.1.0.4.1
+
+The script called build_lustre_2.12.6_client_centOS_hpc_78.sh can be used to build a lustre 2.12.6 client on the new CentOS-HPC image (with MOFED 5.2.x). This script can easily be include in a custom image.


### PR DESCRIPTION
The official lustre 2.12.6 client will not build on the new CentOS-HPC 7.8 marketplace image (with MOFED 5.2.x)

The script build_lustre_2.12.6_client_centOS_hpc_78.sh can build the Lustre 2.12.6 client on the new CentOS-HPC 7.8 marketplace image.