### PR TITLE
Update node_healthchecks.sh

### DIFF
--- a/examples/simple_hpc_pbs/config.json
+++ b/examples/simple_hpc_pbs/config.json
@@ -43,6 +43,7 @@
             "type": "vmss",
             "vm_type": "variables.vm_type",
             "instances": "variables.compute_instances",
+            "accelerated_networking": false,
             "low_priority": "variables.low_priority",
             "image": "variables.hpc_image",
             "subnet": "compute",

--- a/scripts/node_healthchecks.sh
+++ b/scripts/node_healthchecks.sh
@@ -35,11 +35,12 @@ function check_ib_device()
         standard_hc44rs|standard_hb60rs|standard_hb120rs_v2)
             # Retrieve IB info
             ib_device=$(ifconfig | grep ib0 -A1 | grep inet | tr -s ' ' | cut -d' ' -f 3)
+            IBDV=$(ibdev2netdev | grep "ib0" | awk -F ' ' '{print $1}')
             if [ -n "$ib_device" ]; then
-                IB_STATE=$(ibv_devinfo | grep state | xargs | cut -d' ' -f2)
-                IB_RATE=$(ibv_devinfo -v | grep active_width | cut -d':' -f2 | xargs | cut -d' ' -f1)
-                IB_SPEED=$(ibv_devinfo -v | grep active_speed | cut -d':' -f2 | xargs | cut -d'(' -f1 | xargs)
-                IB_PHYS_STATE=$(ibv_devinfo -v | grep phys_state | cut -d':' -f2 | xargs | cut -d' ' -f1)
+                IB_STATE=$(ibv_devinfo -d $IBDV | grep state | xargs | cut -d' ' -f2)
+                IB_RATE=$(ibv_devinfo -d $IBDV -v | grep active_width | cut -d':' -f2 | xargs | cut -d' ' -f1)
+                IB_SPEED=$(ibv_devinfo -d $IBDV -v | grep active_speed | cut -d':' -f2 | xargs | cut -d'(' -f1 | xargs)
+                IB_PHYS_STATE=$(ibv_devinfo -d $IBDV -v | grep phys_state | cut -d':' -f2 | xargs | cut -d' ' -f1)
             else
                 echo "ERROR : No IB devices found"
                 bad_node=1


### PR DESCRIPTION
when accelerated networking is activated on the compute nodes, two network switches are available. The original code selects the first, which can be the eth device sometimes. The eth device has a low speed, so the test fails. This fix allows the script to find the proper IB device and check its speed.