### PR TITLE
update build_wrf.sh

### DIFF
--- a/apps/wrf/build_wrf.sh
+++ b/apps/wrf/build_wrf.sh
@@ -99,7 +99,7 @@ function create_links {
     NETCDF_C=$(spack location -i netcdf-c^${MPI_TYPE})
     echo "NETCDF_C=$NETCDF_C"
     ln -sf $NETCDF_C/include/* $NETCDF/include/
-    ln -sf $NETCDF_C/lib/* $NETCDF/lib/
+    ln -sf $(ls -p $NETCDF_C/lib/* | grep / ) $NETCDF/lib/
     ln -sf $NETCDF_C/lib/pkgconfig/* $NETCDF/lib/pkgconfig
 }
 
@@ -115,6 +115,8 @@ $CONFIG_VALUE
 
 EOF
 }
+
+sudo dnf config-manager --set-enabled PowerTools
 
 install_packages
 get_version


### PR DESCRIPTION
the changes allow the installation of jasper-devel libpng-devel on centOS8 (sudo dnf config-manager --set-enabled PowerTools is necessary)
the second change prevents ln from linking directories (which causes an error): ln -sf $(ls -p $NETCDF_C/lib/* | grep / ) $NETCDF/lib/