### PR TITLE
Simple SLURM cluster example

### DIFF
--- a/examples/simple_hpc_slurm/config.json
+++ b/examples/simple_hpc_slurm/config.json
@@ -1,0 +1,144 @@
+{
+    "location": "variables.location",
+    "resource_group": "variables.resource_group",
+    "install_from": "headnode",
+    "admin_user": "hpcadmin",
+    "variables": {
+        "hpc_image": "OpenLogic:CentOS-HPC:7_9:latest",
+        "slurm_version": "20.11.8",
+        "location": "<NOT-SET>",
+        "resource_group": "<NOT-SET>",
+        "vm_type": "<NOT-SET>",
+        "compute_instances": 2,
+        "low_priority": false,
+        "vnet_resource_group": "variables.resource_group"
+    },
+    "vnet": {
+        "resource_group": "variables.vnet_resource_group",
+        "name": "hpcvnet",
+        "address_prefix": "10.2.0.0/20",
+        "subnets": {
+            "compute": "10.2.4.0/22"
+        }
+    },
+    "resources": {
+        "headnode": {
+            "type": "vm",
+            "vm_type": "Standard_D8s_v3",
+            "accelerated_networking": true,
+            "public_ip": true,
+            "image": "variables.hpc_image",
+            "subnet": "compute",
+            "data_disks": [1024, 1024],
+            "storage_sku": "Premium_LRS",
+            "tags": [
+                "cndefault",
+                "nfsserver",
+                "munge",
+                "slurmctld",
+                "slurmnodes",
+                "localuser",
+                "disable-selinux"
+            ]
+        },
+        "compute": {
+            "type": "vmss",
+            "vm_type": "variables.vm_type",
+            "instances": "variables.compute_instances",
+            "accelerated_networking": false,
+            "low_priority": "variables.low_priority",
+            "image": "variables.hpc_image",
+            "subnet": "compute",
+            "tags": [
+                "nfsclient",
+                "munge",
+                "slurmd",
+                "slurmstart",
+                "cndefault",
+                "localuser",
+                "disable-selinux"
+            ]
+        }
+    },
+    "install": [
+        {
+            "script": "disable-selinux.sh",
+            "tag": "disable-selinux",
+            "sudo": true
+        },
+        {
+            "script": "cndefault.sh",
+            "tag": "cndefault",
+            "sudo": true
+        },
+        {
+            "script": "create_raid0.sh",
+            "tag": "nfsserver",
+            "args": ["/dev/md10", "/dev/sd[c-d]"],
+            "sudo": true
+        },
+        {
+            "script": "make_filesystem.sh",
+            "tag": "nfsserver",
+            "args": ["/dev/md10", "xfs", "/share"],
+            "sudo": true
+        },
+        {
+            "script": "install-nfsserver.sh",
+            "tag": "nfsserver",
+            "args": ["/share"],
+            "sudo": true
+        },
+        {
+            "script": "nfsclient.sh",
+            "args": [
+                "$(<hostlists/tags/nfsserver)"
+            ],
+            "tag": "nfsclient",
+            "sudo": true
+        },
+        {
+            "script": "localuser.sh",
+            "args": [
+                "$(<hostlists/tags/nfsserver)"
+            ],
+            "tag": "localuser",
+            "sudo": true
+        },
+        {
+            "script": "munge.sh",
+            "args": ["abcdefghijklmnopqrstuvwxyz123456"],
+            "tag": "munge",
+            "sudo": true
+        },
+        {
+            "script": "slurmctld.sh",
+            "args": ["variables.slurm_version"],
+            "tag": "slurmctld",
+            "sudo": true
+        },
+        {
+            "script": "slurmd.sh",
+            "tag": "slurmd",
+            "sudo": true
+        },
+        {
+            "script": "slurmnodes.sh",
+            "tag": "slurmnodes",
+            "sudo": true
+        },
+        {
+            "script": "slurmstart.sh",
+            "tag": "slurmstart",
+            "sudo": true
+        },
+        {
+            "script": "node_healthchecks.sh",
+            "tag": "pbsclient",
+            "sudo": true,
+            "args": [
+            ],
+            "deps" : ["install-azcopy.sh","healthchecks.json"]
+        } 
+    ]
+}

--- a/examples/simple_hpc_slurm/readme.md
+++ b/examples/simple_hpc_slurm/readme.md
@@ -38,11 +38,22 @@ Allow ~10 minutes for deployment.  You are able to view the status VMs being dep
 Connect to the headnode and check SLURM and NFS
 
 ```
-$ azhpc-connect -u hpcuser headnode
-Fri Jun 28 09:18:04 UTC 2019 : logging in to headnode (via headnode6cfe86.westus2.cloudapp.azure.com)
+$ azhpc connect -u hpcuser headnode
+[2021-07-09 17:55:37] logging directly into headnode14234.westeurope.cloudapp.azure.com
 [hpcuser@headnode ~]$ sinfo -Nel
+Fri Jul 09 16:55:43 2021
+NODELIST       NODES PARTITION       STATE CPUS    S:C:T MEMORY TMP_DISK WEIGHT AVAIL_FE REASON              
+compute000000      1  compute*        idle 44     2:22:1 354545        0      1   (null) none                
+compute000003      1  compute*        idle 44     2:22:1 354545        0      1   (null) none                
+[hpcuser@headnode ~]$ sinfo
+PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
+compute*     up   infinite      2   idle compute[000000,000003]
 [hpcuser@headnode ~]$ sudo exportfs -v
-[hpcuser@headnode ~]$
+/share/apps     <world>(sync,wdelay,hide,no_subtree_check,sec=sys,rw,secure,no_root_squash,no_all_squash)
+/share/data     <world>(sync,wdelay,hide,no_subtree_check,sec=sys,rw,secure,no_root_squash,no_all_squash)
+/share/home     <world>(sync,wdelay,hide,no_subtree_check,sec=sys,rw,secure,no_root_squash,no_all_squash)
+/mnt/resource/scratch
+                <world>(sync,wdelay,hide,no_subtree_check,sec=sys,rw,secure,no_root_squash,no_all_squash)
 ```
 
 To check the state of the cluster you can run the following commands
@@ -54,4 +65,79 @@ sinfo
 sinfo -Nel
 df -h
 ```
+## Using the cluster
 
+Example of using SLURM for interactive job running Intel MPI Benchmark:
+
+```
+[hpcuser@headnode ~]$ module add mpi/impi
+[hpcuser@headnode ~]$ salloc -N2 -n2
+salloc: Granted job allocation 6
+[hpcuser@compute000000 ~]$ which mpiexec
+/opt/intel/compilers_and_libraries_2018.5.274/linux/mpi/intel64/bin/mpiexec
+[hpcuser@compute000000 ~]$ mpiexec hostname
+compute000000
+compute000003
+[hpcuser@compute000000 ~]$ mpiexec IMB-MPI1 pingpong
+#------------------------------------------------------------
+#    Intel (R) MPI Benchmarks 2018, MPI-1 part    
+#------------------------------------------------------------
+# Date                  : Fri Jul  9 17:17:01 2021
+# Machine               : x86_64
+# System                : Linux
+# Release               : 3.10.0-1160.24.1.el7.x86_64
+# Version               : #1 SMP Thu Apr 8 19:51:47 UTC 2021
+# MPI Version           : 3.1
+# MPI Thread Environment: 
+
+
+# Calling sequence was: 
+
+# IMB-MPI1 pingpong
+
+# Minimum message length in bytes:   0
+# Maximum message length in bytes:   4194304
+#
+# MPI_Datatype                   :   MPI_BYTE 
+# MPI_Datatype for reductions    :   MPI_FLOAT
+# MPI_Op                         :   MPI_SUM  
+#
+#
+
+# List of Benchmarks to run:
+
+# PingPong
+
+#---------------------------------------------------
+# Benchmarking PingPong 
+# #processes = 2 
+#---------------------------------------------------
+       #bytes #repetitions      t[usec]   Mbytes/sec
+            0         1000         1.97         0.00
+            1         1000         1.97         0.51
+            2         1000         2.07         0.97
+            4         1000         1.96         2.04
+            8         1000         1.96         4.09
+           16         1000         2.07         7.71
+           32         1000         2.85        11.22
+           64         1000         2.84        22.54
+          128         1000         2.90        44.20
+          256         1000         3.04        84.07
+          512         1000         3.10       164.92
+         1024         1000         3.30       310.49
+         2048         1000         3.72       550.23
+         4096         1000         4.39       932.50
+         8192         1000         5.90      1387.66
+        16384         1000         7.86      2083.70
+        32768         1000        10.65      3076.66
+        65536          640        15.48      4232.81
+       131072          320        23.73      5523.54
+       262144          160       299.18       876.21
+       524288           80       702.23       746.61
+      1048576           40       771.87      1358.48
+      2097152           20       902.10      2324.73
+      4194304           10      1156.95      3625.31
+
+
+# All processes entering MPI_Finalize
+```

--- a/examples/simple_hpc_slurm/readme.md
+++ b/examples/simple_hpc_slurm/readme.md
@@ -1,0 +1,57 @@
+# Build a SLURM  cluster
+
+Visualisation: [config.json](https://azurehpc.azureedge.net/?o=https://raw.githubusercontent.com/Azure/azurehpc/master/examples/simple_hpc_slurm/config.json)
+
+This example will create an HPC cluster ready to run with SLURM.
+
+## Initialise the project
+
+To start you need to copy this directory and update the `config.json`.  Azurehpc provides the `azhpc-init` command that can help here by copying the directory and substituting the unset variables.  First run with the `-s` parameter to see which variables need to be set:
+
+```
+azhpc-init -c $azhpc_dir/examples/simple_hpc_slurm -d simple_hpc_slurm -s
+```
+
+The variables can be set with the `-v` option where variables are comma separated.  The output from the previous command as a starting point.  The `-d` option is required and will create a new directory name for you.  Please update to whatever `resource_group` you would like to deploy to:
+
+```
+azhpc-init -c $azhpc_dir/examples/simple_hpc_slurm -d simple_hpc_slurm -v resource_group=azurehpc-cluster
+```
+
+> Note:  You can still update variables even if they are already set.  For example, in the command below we change the region to `westus2` and the SKU to `Standard_HC44rs`:
+
+```
+azhpc-init -c $azhpc_dir/examples/simple_hpc_slurm -d simple_hpc_slurm -v location=westus2,vm_type=Standard_HC44rs,resource_group=azhpc-cluster
+```
+
+## Create the cluster 
+
+```
+cd simple_hpc_slurm
+azhpc-build
+```
+
+Allow ~10 minutes for deployment.  You are able to view the status VMs being deployed by running `azhpc-status` in another terminal.
+
+## Log in the cluster
+
+Connect to the headnode and check SLURM and NFS
+
+```
+$ azhpc-connect -u hpcuser headnode
+Fri Jun 28 09:18:04 UTC 2019 : logging in to headnode (via headnode6cfe86.westus2.cloudapp.azure.com)
+[hpcuser@headnode ~]$ sinfo -Nel
+[hpcuser@headnode ~]$ sudo exportfs -v
+[hpcuser@headnode ~]$
+```
+
+To check the state of the cluster you can run the following commands
+
+```
+azhpc-connect -u hpcuser headnode
+squeue
+sinfo
+sinfo -Nel
+df -h
+```
+

--- a/examples/simple_hpc_slurm/scripts/munge.sh
+++ b/examples/simple_hpc_slurm/scripts/munge.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+MUNGEKEY=$1
+
+yum install -y epel-release
+yum install munge munge-libs munge-devel -y
+
+echo ${MUNGEKEY} > /etc/munge/munge.key
+chown munge /etc/munge/munge.key
+chmod 600 /etc/munge/munge.key
+systemctl enable munge
+systemctl start munge

--- a/examples/simple_hpc_slurm/scripts/slurmctld.sh
+++ b/examples/simple_hpc_slurm/scripts/slurmctld.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+yum install -y epel-release screen
+
+yum install python3 perl-ExtUtils-MakeMaker gcc mariadb-devel openssl openssl-devel pam-devel rpm-build numactl numactl-devel hwloc hwloc-devel lua lua-devel readline-devel rrdtool-devel ncurses-devel man2html libibmad libibumad -y
+
+# for multiple partition nodeset will be useful
+#yum install -y python2-clustershell
+
+slurm_version=${1:-20.11.8}
+slurm_tarball=slurm-20.11.8.tar.bz2
+if [ ! -f $slurm_tarball ]; then
+  wget https://download.schedmd.com/slurm/$slurm_tarball
+fi
+
+if [ ! -f "/apps/rpms/slurm*.rpm" ]; then
+  rpmbuild -ta $slurm_tarball
+  mkdir -p /apps/rpms
+  cp /root/rpmbuild/RPMS/x86_64/slurm-* /apps/rpms/
+fi
+
+yum install -y /apps/rpms/slurm-*
+
+export SLURMUSER=1002
+groupadd -g $SLURMUSER slurm
+useradd  -m -c "SLURM workload manager" -d /var/lib/slurm -u $SLURMUSER -g slurm  -s /bin/bash slurm
+
+mkdir -p /var/spool/slurm
+chown slurm /var/spool/slurm
+mkdir -p /var/log/slurm
+chown slurm /var/log/slurm
+mkdir -p /apps/slurm
+
+# Create slurm.conf
+cat <<EOF > /apps/slurm/slurm.conf
+ClusterName=cluster
+
+SlurmctldHost=`hostname -s`
+SlurmUser=slurm
+SlurmctldPort=6817
+SlurmdPort=6818
+SlurmctldPidFile=/var/run/slurmctld.pid
+SlurmdPidFile=/var/run/slurmd.pid
+SlurmdSpoolDir=/var/spool/slurm
+StateSaveLocation=/var/spool/slurm/state
+
+AuthType=auth/munge
+
+ProctrackType=proctrack/cgroup
+TaskPlugin=task/affinity,task/cgroup
+
+SelectType=select/cons_res
+SelectTypeParameters=CR_CPU_Memory
+
+SchedulerType=sched/backfill
+SchedulerParameters=salloc_wait_nodes
+
+SuspendTime=300
+SuspendTimeout=600
+ResumeTimeout=1800
+#SuspendProgram=/apps/slurm/scripts/suspend.sh
+#ResumeProgram=/apps/slurm/scripts/resume.sh
+#ResumeFailProgram=/apps/slurm/scripts/suspend.sh
+
+SlurmctldTimeout=300
+SlurmdTimeout=300
+
+#SlurmctldParameters=cloud_dns,idle_on_node_suspend
+#CommunicationParameters=NoAddrCache
+
+PropagateResourceLimits=NONE
+
+SlurmctldLogFile=/var/log/slurm/slurmctld.log
+SlurmctldDebug=debug5
+SlurmdLogFile=/var/log/slurm/slurmd.log
+SlurmdDebug=debug5
+DebugFlags=PowerSave
+
+PrivateData=cloud
+ReturnToService=2
+
+LaunchParameters=use_interactive_step
+#InteractiveStepOptions=--mem-per-cpu=0 --cpu_bind=no --preserve-env --pty /bin/bash
+
+include /apps/slurm/nodes.conf
+include /apps/slurm/partitions.conf
+
+EOF
+
+# Create cgroup.conf
+cat <<EOF > /apps/slurm/cgroup.conf
+CgroupMountpoint=/sys/fs/cgroup
+CgroupAutomount=yes
+ConstrainCores=yes
+TaskAffinity=no
+ConstrainRAMSpace=yes
+ConstrainSwapSpace=no
+ConstrainDevices=no
+
+EOF
+
+ln -s /apps/slurm/slurm.conf /etc/slurm/slurm.conf
+ln -s /apps/slurm/cgroup.conf /etc/slurm/cgroup.conf
+
+#mkdir -p /apps/slurm/scripts
+#
+#cp scripts/suspend.sh /apps/slurm/scripts/
+#cp scripts/resume.sh /apps/slurm/scripts/
+#
+#chmod +x /apps/slurm/scripts/*.sh
+#ls -alh /apps/slurm/scripts
+#
+#mkdir -p /apps/slurm/azscale/scripts
+#cp scripts/config.json /apps/slurm/azscale
+#cp scripts/*_id_rsa* /apps/slurm/azscale
+#chmod 600 /apps/slurm/azscale/*_id_rsa
+#chmod 644 /apps/slurm/azscale/*_id_rsa.pub
+#cp -r scripts /apps/slurm/azscale/.
+#pushd /apps/slurm
+#git clone https://github.com/Azure/azurehpc.git
+#popd
+
+chown slurm.slurm -R /apps/slurm
+mkdir -p /apps/slurm/nodeconf
+
+systemctl enable slurmctld
+
+exit 0

--- a/examples/simple_hpc_slurm/scripts/slurmctld.sh
+++ b/examples/simple_hpc_slurm/scripts/slurmctld.sh
@@ -4,11 +4,8 @@ yum install -y epel-release screen
 
 yum install python3 perl-ExtUtils-MakeMaker gcc mariadb-devel openssl openssl-devel pam-devel rpm-build numactl numactl-devel hwloc hwloc-devel lua lua-devel readline-devel rrdtool-devel ncurses-devel man2html libibmad libibumad -y
 
-# for multiple partition nodeset will be useful
-#yum install -y python2-clustershell
-
 slurm_version=${1:-20.11.8}
-slurm_tarball=slurm-20.11.8.tar.bz2
+slurm_tarball=slurm-${slurm_version}.tar.bz2
 if [ ! -f $slurm_tarball ]; then
   wget https://download.schedmd.com/slurm/$slurm_tarball
 fi
@@ -101,24 +98,6 @@ EOF
 
 ln -s /apps/slurm/slurm.conf /etc/slurm/slurm.conf
 ln -s /apps/slurm/cgroup.conf /etc/slurm/cgroup.conf
-
-#mkdir -p /apps/slurm/scripts
-#
-#cp scripts/suspend.sh /apps/slurm/scripts/
-#cp scripts/resume.sh /apps/slurm/scripts/
-#
-#chmod +x /apps/slurm/scripts/*.sh
-#ls -alh /apps/slurm/scripts
-#
-#mkdir -p /apps/slurm/azscale/scripts
-#cp scripts/config.json /apps/slurm/azscale
-#cp scripts/*_id_rsa* /apps/slurm/azscale
-#chmod 600 /apps/slurm/azscale/*_id_rsa
-#chmod 644 /apps/slurm/azscale/*_id_rsa.pub
-#cp -r scripts /apps/slurm/azscale/.
-#pushd /apps/slurm
-#git clone https://github.com/Azure/azurehpc.git
-#popd
 
 chown slurm.slurm -R /apps/slurm
 mkdir -p /apps/slurm/nodeconf

--- a/examples/simple_hpc_slurm/scripts/slurmd.sh
+++ b/examples/simple_hpc_slurm/scripts/slurmd.sh
@@ -14,9 +14,10 @@ chown slurm /var/log/slurm
 ln -s /apps/slurm/slurm.conf /etc/slurm/slurm.conf
 ln -s /apps/slurm/cgroup.conf /etc/slurm/cgroup.conf
 
+# Collect the actual hardware configuration of the node
+
 slurmd -C | grep $HOSTNAME > /apps/slurm/nodeconf/$HOSTNAME
 
 systemctl enable slurmd
-#systemctl start slurmd
 
 exit 0

--- a/examples/simple_hpc_slurm/scripts/slurmd.sh
+++ b/examples/simple_hpc_slurm/scripts/slurmd.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+yum install -y /apps/rpms/slurm-*
+
+export SLURMUSER=1002
+groupadd -g $SLURMUSER slurm
+useradd  -m -c "SLURM workload manager" -d /var/lib/slurm -u $SLURMUSER -g slurm  -s /bin/bash slurm
+
+mkdir -p /var/spool/slurm
+chown slurm /var/spool/slurm
+mkdir -p /var/log/slurm
+chown slurm /var/log/slurm
+
+ln -s /apps/slurm/slurm.conf /etc/slurm/slurm.conf
+ln -s /apps/slurm/cgroup.conf /etc/slurm/cgroup.conf
+
+slurmd -C | grep $HOSTNAME > /apps/slurm/nodeconf/$HOSTNAME
+
+systemctl enable slurmd
+#systemctl start slurmd
+
+exit 0

--- a/examples/simple_hpc_slurm/scripts/slurmnodes.sh
+++ b/examples/simple_hpc_slurm/scripts/slurmnodes.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+cat /apps/slurm/nodeconf/* | sort > /apps/slurm/nodes.conf
+#nodeset=$(cat hostlists/compute | nodeset -f)
+partition=compute
+
+echo "PartitionName=${partition} Nodes=ALL Default=YES MaxTime=INFINITE State=UP" > /apps/slurm/partitions.conf
+
+systemctl restart slurmctld

--- a/examples/simple_hpc_slurm/scripts/slurmnodes.sh
+++ b/examples/simple_hpc_slurm/scripts/slurmnodes.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 cat /apps/slurm/nodeconf/* | sort > /apps/slurm/nodes.conf
-#nodeset=$(cat hostlists/compute | nodeset -f)
 partition=compute
 
 echo "PartitionName=${partition} Nodes=ALL Default=YES MaxTime=INFINITE State=UP" > /apps/slurm/partitions.conf

--- a/examples/simple_hpc_slurm/scripts/slurmstart.sh
+++ b/examples/simple_hpc_slurm/scripts/slurmstart.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+systemctl start slurmd
+
+exit 0


### PR DESCRIPTION
Simple SLURM cluster based on simple_hpc_pbs example. headnode + compute nodes in vmss. Single partition, any VM size should work.
Uses latest SLURM release at the time.