### PR TITLE
Use Standard SKU Public IP as default

### DIFF
--- a/pyazhpc/arm.py
+++ b/pyazhpc/arm.py
@@ -564,7 +564,12 @@ class ArmTemplate:
                     "location": loc,
                     "dependsOn": [],
                     "tags": gtags,
+                    "sku": {
+                        "name": "Standard",
+                        "tier": "Regional"
+                    },
                     "properties": {
+                        "publicIPAllocationMethod": "Static",
                         "dnsSettings": {
                             "domainNameLabel": dnsname
                         }


### PR DESCRIPTION
The Public IP Standard SKU will be the required one instead of Basic.
This PR sets the correct SKU in the generated ARM template.