### PR TITLE
Update GPU Monitoring scripts

### DIFF
--- a/experimental/gpu_monitoring/start_gpu_data_collector.sh
+++ b/experimental/gpu_monitoring/start_gpu_data_collector.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 HOSTLIST=hostlist
-INTERVAL_MINS=1
+INTERVAL_SECS=30
+DCGM_FIELD_IDS="203,252,1004"
 SCRIPT_PATH=~
-EXE_PATH="python3 ${SCRIPT_PATH}/gpu_data_collector.py \>\> /tmp/gpu_data_collector.log"
+EXE_PATH="${SCRIPT_PATH}/gpu_data_collector.py -tis $INTERVAL_SECS -dfi $DCGM_FIELD_IDS \>\> /tmp/gpu_data_collector.log"
 PDSH_RCMD_TYPE=ssh
 
 
-WCOLL=$HOSTLIST pdsh "if ! [ -f /etc/crontab.orig ]; then sudo cp /etc/crontab /etc/crontab.orig; echo "\*/$INTERVAL_MINS \\* \\* \\* \\* root $EXE_PATH" 2>&1 | sudo tee -a /etc/crontab;fi"
+WCOLL=$HOSTLIST pdsh sudo $EXE_PATH

--- a/experimental/gpu_monitoring/start_gpu_data_collector_cron.sh
+++ b/experimental/gpu_monitoring/start_gpu_data_collector_cron.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+HOSTLIST=hostlist
+INTERVAL_MINS=1
+SCRIPT_PATH=~
+EXE_PATH="${SCRIPT_PATH}/gpu_data_collector.py -uc \>\> /tmp/gpu_data_collector.log"
+PDSH_RCMD_TYPE=ssh
+
+
+WCOLL=$HOSTLIST pdsh "if ! [ -f /etc/crontab.orig ]; then sudo cp /etc/crontab /etc/crontab.orig; echo "\*/$INTERVAL_MINS \\* \\* \\* \\* root $EXE_PATH" 2>&1 | sudo tee -a /etc/crontab;fi"

--- a/experimental/gpu_monitoring/stop_gpu_data_collector.sh
+++ b/experimental/gpu_monitoring/stop_gpu_data_collector.sh
@@ -4,4 +4,4 @@ HOSTLIST=hostlist
 PDSH_RCMD_TYPE=ssh
 
 
-WCOLL=$HOSTLIST pdsh sudo mv /etc/crontab.orig /etc/crontab
+WCOLL=$HOSTLIST pdsh sudo pkill gpu_data_collector

--- a/experimental/gpu_monitoring/stop_gpu_data_collector_cron.sh
+++ b/experimental/gpu_monitoring/stop_gpu_data_collector_cron.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+HOSTLIST=hostlist
+PDSH_RCMD_TYPE=ssh
+
+
+WCOLL=$HOSTLIST pdsh sudo mv /etc/crontab.orig /etc/crontab


### PR DESCRIPTION
-Added multiple arguments, to give finer control and flexibility to the GPU Monitor
- Can deploy as stand-alone or via crontab.

./gpu_data_collector.py -h
usage: gpu_data_collector.py [-h] [-dfi DCGM_FIELD_IDS] [-nle NAME_LOG_EVENT]
                             [-fgm] [-uc] [-tis TIME_INTERVAL_SECONDS]

optional arguments:
  -h, --help            show this help message and exit
  -dfi DCGM_FIELD_IDS, --dcgm_field_ids DCGM_FIELD_IDS
                        Select the DCGM field ids you would like to monitor
                        (if multiple field ids  are desired then separate by commas)
                        [string] (default: 203,252,1004)
  -nle NAME_LOG_EVENT, --name_log_event NAME_LOG_EVENT
                        Select a name for the log events you want to monitor
                        (default: MyGPUMonitor)
  -fgm, --force_gpu_monitoring
                        Forces data to be sent to log analytics WS even if no
                        SLURM job is running on the node (default: False)
  -uc, --use_crontab    This script will be started by the system contab and
                        the time interval between each data collection will be
                        decided by the system crontab (if crontab is selected
                        then the -tis argument will be ignored). (default:
                        False)
  -tis TIME_INTERVAL_SECONDS, --time_interval_seconds TIME_INTERVAL_SECONDS
                        The time interval in seconds between each data
                        collection (This option cannot be used with the -uc
                        argument) (default: 30)