### PR TITLE
GPU optimizations (Set maximum application GPU clock frequencies)

### DIFF
--- a/experimental/gpu_optimizations/max_gpu_app_clocks.sh
+++ b/experimental/gpu_optimizations/max_gpu_app_clocks.sh
@@ -26,7 +26,9 @@ do
       IFS=$', '
       gpu_freq_line=( $gpu_freq_out )
       IFS=$' \t\n'
-      if [[ ${gpu_freq_line[0]} -gt ${gpu_freq_line[1]} || ${gpu_freq_line[2]} -gt ${gpu_freq_line[3]} ]]; then
+      if [[ $1 == "-l" ]]; then
+	      echo "GPU Id: $device, GPU memory freq (max,current)= (${gpu_freq_line[0]},${gpu_freq_line[1]}) MHz, GPU graphics freq (max,current) = (${gpu_freq_line[2]},${gpu_freq_line[3]}) MHz" 
+      elif [[ ${gpu_freq_line[0]} -gt ${gpu_freq_line[1]} || ${gpu_freq_line[2]} -gt ${gpu_freq_line[3]} ]]; then
          set_gpu_freq_out=$(nvidia-smi -i $device -ac ${gpu_freq_line[0]},${gpu_freq_line[2]})
          set_gpu_freq_out_rc=$?
          if [[ $set_gpu_freq_out_rc != 0 ]]; then

--- a/experimental/gpu_optimizations/max_gpu_app_clocks.sh
+++ b/experimental/gpu_optimizations/max_gpu_app_clocks.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Set or reset the application max GPU clock frequencies
+# If no arguments, then set Max GPU clock frequencies, if -r argment used then reset the GPU frequencies.
+
+GPU_QUERY="clocks.max.memory,clocks.applications.memory,clocks.max.graphics,clocks.applications.graphics"
+
+for device in {0..7};
+do
+   if [[ $1 == "-r" ]]; then
+      reset_gpu_freq_out=$(nvidia-smi -i $device -rac)
+      reset_gpu_freq_out_rc=$?
+      if [[ $reset_gpu_freq_out_rc != 0 ]]; then
+         echo "Error: nvidia-smi (reset gpu max freqs) did not run correctly, $reset_gpu_freq_out"
+      else
+	 echo "On GPU Id $device, $reset_gpu_freq_out"
+      fi
+   else
+      gpu_freq_out=$(nvidia-smi -i $device --query-gpu=$GPU_QUERY --format=csv,noheader,nounits)
+      gpu_freq_out_rc=$?
+      if [[ $gpu_freq_out_rc != 0 ]]
+      then
+         echo "Error: nvidia-smi (gpu freqs) did not run correctly, $gpu_freq_out"
+         exit 1
+      fi
+      IFS=$', '
+      gpu_freq_line=( $gpu_freq_out )
+      IFS=$' \t\n'
+      if [[ ${gpu_freq_line[0]} -gt ${gpu_freq_line[1]} || ${gpu_freq_line[2]} -gt ${gpu_freq_line[3]} ]]; then
+         set_gpu_freq_out=$(nvidia-smi -i $device -ac ${gpu_freq_line[0]},${gpu_freq_line[2]})
+         set_gpu_freq_out_rc=$?
+         if [[ $set_gpu_freq_out_rc != 0 ]]; then
+            echo "Error: nvidia-smi (set gpu max freqs) did not run correctly, $set_gpu_freq_out"
+            exit 1
+         fi
+         echo "On GPU Id $device, $set_gpu_freq_out"
+      else
+         echo "GPU Id $device, max application GPU clocks are already set, GPU memory is  ${gpu_freq_line[0]} MHz and GPU graphics is ${gpu_freq_line[2]} MHz"
+      fi
+   fi
+done

--- a/experimental/gpu_optimizations/max_gpu_app_clocks.sh
+++ b/experimental/gpu_optimizations/max_gpu_app_clocks.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-# Set or reset the application max GPU clock frequencies
-# If no arguments, then set Max GPU clock frequencies, if -r argment used then reset the GPU frequencies.
+# Set the application maximum GPU clock frequencies. (default, no arguments)
+# Reset the application  GPU clock frequencies. (-r argument)
+# List the application current and maximum GPU clock frequencies. (-l argument)
+
 
 GPU_QUERY="clocks.max.memory,clocks.applications.memory,clocks.max.graphics,clocks.applications.graphics"
 

--- a/experimental/gpu_optimizations/readme.md
+++ b/experimental/gpu_optimizations/readme.md
@@ -6,7 +6,7 @@ This directory contains scripts that help performance on GPU's (e.g NDv4, A100).
 
 - Tested on ND96asr_v4 (A100) running Ubuntu-HPC 18.04
 
-## Set Max application GPU clock frequencies
+## Max application GPU clock frequencies
 Setting the application GPU memory and graphics clock frequences to their maximum values can improve GPU performance.
 The script max_gpu_app_clocks.sh can set the GPU's to their maximum application GPU clock frequencies or reset to the 
 default application GPU clock frequencies (-r option).
@@ -46,4 +46,17 @@ On GPU Id 5, All done.
 On GPU Id 6, All done.
 On GPU Id 7, All done.
 ```
->Note: The -r argument to reset the application GPU clock frequencies
+
+To list the current and maximum application GPU clock frequencies.
+
+```
+sudo ./max_gpu_app_clocks.sh -l
+GPU Id: 0, GPU memory freq (max,current)= (1215,1215) MHz, GPU graphics freq (max,current) = (1410,1095) MHz
+GPU Id: 1, GPU memory freq (max,current)= (1215,1215) MHz, GPU graphics freq (max,current) = (1410,1095) MHz
+GPU Id: 2, GPU memory freq (max,current)= (1215,1215) MHz, GPU graphics freq (max,current) = (1410,1095) MHz
+GPU Id: 3, GPU memory freq (max,current)= (1215,1215) MHz, GPU graphics freq (max,current) = (1410,1095) MHz
+GPU Id: 4, GPU memory freq (max,current)= (1215,1215) MHz, GPU graphics freq (max,current) = (1410,1095) MHz
+GPU Id: 5, GPU memory freq (max,current)= (1215,1215) MHz, GPU graphics freq (max,current) = (1410,1095) MHz
+GPU Id: 6, GPU memory freq (max,current)= (1215,1215) MHz, GPU graphics freq (max,current) = (1410,1095) MHz
+GPU Id: 7, GPU memory freq (max,current)= (1215,1215) MHz, GPU graphics freq (max,current) = (1410,1095) MHz
+```

--- a/experimental/gpu_optimizations/readme.md
+++ b/experimental/gpu_optimizations/readme.md
@@ -1,0 +1,49 @@
+# GPU Optimization 
+
+This directory contains scripts that help performance on GPU's (e.g NDv4, A100).
+
+## Prerequisites
+
+- Tested on ND96asr_v4 (A100) running Ubuntu-HPC 18.04
+
+## Set Max application GPU clock frequencies
+Setting the application GPU memory and graphics clock frequences to their maximum values can improve GPU performance.
+The script max_gpu_app_clocks.sh can set the GPU's to their maximum application GPU clock frequencies or reset to the 
+default application GPU clock frequencies (-r option).
+
+To set the application maximum GPU clock frequencies.
+
+```
+sudo ./max_gpu_app_clocks.sh
+On GPU Id 0, Applications clocks set to "(MEM 1215, SM 1410)" for GPU 00000001:00:00.0
+All done.
+On GPU Id 1, Applications clocks set to "(MEM 1215, SM 1410)" for GPU 00000002:00:00.0
+All done.
+On GPU Id 2, Applications clocks set to "(MEM 1215, SM 1410)" for GPU 00000003:00:00.0
+All done.
+On GPU Id 3, Applications clocks set to "(MEM 1215, SM 1410)" for GPU 00000004:00:00.0
+All done.
+On GPU Id 4, Applications clocks set to "(MEM 1215, SM 1410)" for GPU 0000000B:00:00.0
+All done.
+On GPU Id 5, Applications clocks set to "(MEM 1215, SM 1410)" for GPU 0000000C:00:00.0
+All done.
+On GPU Id 6, Applications clocks set to "(MEM 1215, SM 1410)" for GPU 0000000D:00:00.0
+All done.
+On GPU Id 7, Applications clocks set to "(MEM 1215, SM 1410)" for GPU 0000000E:00:00.0
+All done.
+```
+
+To reset the application GPU clock frequencies
+
+```
+sudo ./max_gpu_app_clocks.sh -r
+On GPU Id 0, All done.
+On GPU Id 1, All done.
+On GPU Id 2, All done.
+On GPU Id 3, All done.
+On GPU Id 4, All done.
+On GPU Id 5, All done.
+On GPU Id 6, All done.
+On GPU Id 7, All done.
+```
+>Note: The -r argument to reset the application GPU clock frequencies


### PR DESCRIPTION
Script to set, reset(-r) or list(-l) the GPU application maximum clock frequencies (memory and graphics).
On NDv4 (A100) it's recommended to always set your GPU's to the maximum application clock frequencies to get the best performance.