### PR TITLE
cc_nhc slurm update

### DIFF
--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/configure_nhc.sh
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/configure_nhc.sh
@@ -2,16 +2,16 @@
 
 NHC_SYSCONFIG=/etc
 OS_SYSCONFIG=/etc/default
-NHC_TIMEOUT=300
+NHC_TIMEOUT=200
 NHC_VERBOSE=1
 NHC_DETACHED_MODE=1
 NHC_DEBUG=0
 NHC_CONF_FILE_NEW=$CYCLECLOUD_SPEC_PATH/files/nd96asr_v4.conf
 NHC_EXE=/usr/sbin/nhc
 NHC_NVIDIA_HEALTHMON=dcgmi
-NHC_NVIDIA_HEALTHMON_ARGS="diag -r 2"
+NHC_NVIDIA_HEALTHMON_ARGS="diag -r 1"
 SLURM_CONF=/etc/slurm/slurm.conf
-SLURM_HEALTH_CHECK_INTERVAL=300
+SLURM_HEALTH_CHECK_INTERVAL=200
 SLURM_HEALTH_CHECK_NODE_STATE=IDLE
 NHC_EXTRA_TEST_FILES="csc_nvidia_smi.nhc azure_cuda_bandwidth.nhc azure_gpu_app_clocks.nhc azure_gpu_ecc.nhc azure_gpu_persistence.nhc azure_ib_write_bw_gdr.nhc"
 

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
@@ -68,9 +68,9 @@
  * || check_fs_mount_rw -t "ext4" -s "/dev/sdb1" -f "/mnt"
  * || check_fs_mount_rw -t "fuse.lxcfs" -s "lxcfs" -f "/var/lib/lxcfs"
  * || check_fs_mount_rw -t "tracefs" -s "tracefs" -f "/sys/kernel/debug/tracing"
- * || check_fs_mount_rw -t "nfs4" -s "10.2.4.4:/sched" -f "/sched"
- * || check_fs_mount_rw -t "nfs" -s "10.2.8.4:/anfvol1" -f "/shared"
- * || check_fs_mount_rw -t "xfs" -s "/dev/md128" -f "/mnt/resource_nvme"
+ * || check_fs_mount_rw -t "nfs4" -s "*:/*" -f "/sched"
+ * || check_fs_mount_rw -t "nfs" -s "*:/*" -f "/shared"
+ * || check_fs_mount_rw -t "xfs" -s "/dev/*" -f "/mnt/resource_nvme"
  * || check_fs_used /dev 90%
  * || check_fs_used / 90%
  * || check_fs_used /boot/efi 90%

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
@@ -130,7 +130,7 @@
  * || check_nvsmi_healthmon
  * || check_gpu_persistence
  * || check_nv_healthmon
- * || check_cuda_bw 22.5
+ * || check_cuda_bw 22.3
  * || check_app_gpu_clocks
  * || check_gpu_ecc 5000
 

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
@@ -130,7 +130,7 @@
  * || check_nvsmi_healthmon
  * || check_gpu_persistence
  * || check_nv_healthmon
- * || check_cuda_bw 22.3
+ * || check_cuda_bw 22.1
  * || check_app_gpu_clocks
  * || check_gpu_ecc 5000
 

--- a/experimental/cc_slurm_nhc/readme.md
+++ b/experimental/cc_slurm_nhc/readme.md
@@ -7,7 +7,7 @@ is created to allow this healthcheck framework to be integrated in CycleCloud SL
 
 ## Prerequisites
 
-- CycleCloud 8.2.1 is installed, Ubuntu 18.04, SLURM 2.5.0
+- CycleCloud 8.2.1 is installed, Ubuntu 18.04, SLURM 2.5.0 (Tested with these versions, other versions may work)
 - Compute node(s), ND96asr_v4 (Running Ubuntu-hpc 18.04)
 
 ## Design
@@ -45,7 +45,7 @@ See in the CC Portal Edit-->Advanced-Settings, under Software. Also, added the f
 ```
 SuspendExcParts=hpc
 HealthCheckProgram=/usr/sbin/nhc
-HealthCheckInterval=300
+HealthCheckInterval=200
 HealthCheckNodeState=IDLE
 ```
 >Note: In my case I am disabling autoscaling (SuspendExcParts=hpc), if you have autoscaling enabled you may need to modify these scripts to prevent the 


### PR DESCRIPTION
-  Changed the dcgmi diag test to be the quick test (-r 1)
-  Reduced the SLURM test interval to be 200 seconds
-  Removed any specific IP addresses and device names from the sample NHC configuration file
-  Some minor modifications to the readme file