### PR TITLE
CC slurm nhc ecc update

### DIFF
--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/azure_gpu_ecc.nhc
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/azure_gpu_ecc.nhc
@@ -51,12 +51,12 @@ function check_gpu_ecc() {
          die 1 "$FUNCNAME: GPU id $i: Row remap error"
       fi
       dbg "GPU id $i: No GPU row remap pending or row remap errors"
+      if [[ ${gpu_query_out_line[0]} > 0 || ${gpu_query_out_line[1]} > 0 ]]; then
+         die 1 "$FUNCNAME: GPU id $i: SRAM Uncorrected ECC error count, (${gpu_query_out_line[0]},${gpu_query_out_line[1]})"
+      else
+         dbg "GPU id $i: Normal SRAM Uncorrectable ECC error count, (${gpu_query_out_line[0]},${gpu_query_out_line[1]})"
+      fi
       if [[ -n $1 ]]; then
-         if [[ ${gpu_query_out_line[0]} > $1 || ${gpu_query_out_line[1]} > $1 ]]; then
-	    die 1 "$FUNCNAME: GPU id $i: High SRAM Uncorrected ECC error count, (${gpu_query_out_line[0]},${gpu_query_out_line[1]})"
-         else
-            dbg "GPU id $i: Normal SRAM Uncorrectable ECC error count, (${gpu_query_out_line[0]},${gpu_query_out_line[1]})"
-         fi
          if [[ ${gpu_query_out_line[2]} > $1 || ${gpu_query_out_line[3]} > $1 ]]; then
 	    die 1 "$FUNCNAME: GPU id $i: High DRAM Uncorrected ECC error count, (${gpu_query_out_line[2]},${gpu_query_out_line[3]})"
          else

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96amsr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96amsr_v4.conf
@@ -135,7 +135,7 @@
  * || check_nv_healthmon
  * || check_cuda_bw 22.0
  * || check_app_gpu_clocks
- * || check_gpu_ecc 10000
+ * || check_gpu_ecc 20000
 
 
 #      #######################################################################

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
@@ -132,7 +132,7 @@
  * || check_nv_healthmon
  * || check_cuda_bw 22.1
  * || check_app_gpu_clocks
- * || check_gpu_ecc 10000
+ * || check_gpu_ecc 20000
 
 
 #######################################################################


### PR DESCRIPTION
- Any SRAM ECC error count is an error (>0)
- Increased ECC uncorrectable error count limit to 20000