### PR TITLE
Added script to generate hpc diagnostics file

### DIFF
--- a/experimental/ndv4_a100_healthchecks/gen_hpcdiags.sh
+++ b/experimental/ndv4_a100_healthchecks/gen_hpcdiags.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 #Run pre-installed hpc diagnostics and deposit the compressed tar file in OUTDIR
+#
+# takes one argument, the slurm hostname.
 
 USER=cormac
 OUTDIR=/shared/home/${USER}/hpcdiags

--- a/experimental/ndv4_a100_healthchecks/gen_hpcdiags.sh
+++ b/experimental/ndv4_a100_healthchecks/gen_hpcdiags.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+#Run pre-installed hpc diagnostics and deposit the compressed tar file in OUTDIR
+
+USER=cormac
+OUTDIR=/shared/home/${USER}/hpcdiags
+CLUSTER=cluster_name
+
+sudo chmod 777 /opt/azurehpc/diagnostics/gather_azhpc_vm_diagnostics.sh
+
+sudo rm /opt/azurehpc/diagnostics/*.tar.gz
+
+sudo /opt/azurehpc/diagnostics/gather_azhpc_vm_diagnostics.sh << EOF
+n
+y
+EOF
+
+hpcdiag_path=$(ls /opt/azurehpc/diagnostics/*.tar.gz)
+hpcdiag_file=$(basename $hpcdiag_path)
+cp /opt/azurehpc/diagnostics/*.tar.gz $OUTDIR/${CLUSTER}-$1-$hpcdiag_file


### PR DESCRIPTION
Script will run pre-installed (HPC Marketplace images (e.g ubunt-hpc)) HPC Diagnostics (Useful when reporting an unhealthy node) and deposit the compressed tar file in directory.
Takes one argument the slurm hostname.

