### PR TITLE
CC_SLURM_NHC (Exclude reason sw_power_cap from GPU clock throttling warning)

### DIFF
--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/azure_gpu_clock_throttling.nhc
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/azure_gpu_clock_throttling.nhc
@@ -34,7 +34,7 @@ function check_gpu_clock_throttling() {
       IFS=$', '
       gpu_clock_throttle_out_line=( ${gpu_clock_throttle_out_lines[$i]} )
       IFS=$' \t\n'
-      if [[ ${gpu_clock_throttle_out_line[0]} != $GPU_CLOCKS_THROTTLE_REASON_GPU_IDLE && ${gpu_clock_throttle_out_line[0]} != $GPU_CLOCKS_THROTTLE_REASON_NONE ]]; then
+      if [[ ${gpu_clock_throttle_out_line[0]} != $GPU_CLOCKS_THROTTLE_REASON_GPU_IDLE && ${gpu_clock_throttle_out_line[0]} != $GPU_CLOCKS_THROTTLE_REASON_NONE && ${gpu_clock_throttle_out_line[0]} != $GPU_CLOCKS_THROTTLE_REASON_SW_POWER_CAP ]]; then
          log "Warning: GPU $i throttled, reason=${gpu_clock_throttle_out_line[0]}"
 # Just log GPU throttling (but do not DRAIN node)
 #         die 1 "$FUNCNAME: GPU $i clock throttled, reason=${gpu_clock_throttle_out_line[0]}"


### PR DESCRIPTION
- Exclude SW Power Cap as a reason to give a warning about GPU throttling.