### PR TITLE
Set default ssh_port to be port 22 (bug fix)

### DIFF
--- a/pyazhpc/azinstall.py
+++ b/pyazhpc/azinstall.py
@@ -426,7 +426,7 @@ def __rsync(sshkey, sshport, src, dst):
 
 def run(cfg, tmpdir, adminuser, sshprivkey, sshpubkey, fqdn, startstep=0):
     jb = cfg.get("install_from")
-    sshport = cfg.get("ssh_port")
+    sshport = cfg.get("ssh_port", 22)
     install_steps = [{ "script": "install_node_setup.sh" }] + cfg.get("install", [])
     if jb:
         log.debug("wait for ssh on jumpbox")


### PR DESCRIPTION
ssh_port has no default in azinstall.py which causes the ssh -p option to be set to None (which fails).

If ssh_port is not set then set the default to port 22.