### PR TITLE
Added Support for a customized template file to create a cyclecloud cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ This describes the template and parameters to be applied on a CycleCloud cluster
 |------------|--------------------------------------------------------------------------------------|----------|---------|
 | **template** | The name of the template or template file used to create the cluster.              |   yes    |         |
 | **parameters** | Dictionary of parameters defined in the template. The parameter list can be retrieved with the [cyclecloud export_parameters](https://docs.microsoft.com/en-us/azure/cyclecloud/cli?view=cyclecloud-7#cyclecloud-export_parameters) command |   yes    |         |
+>Note: If template is set to a cyclecloud template file, use the following naming format <scheduler_type>_<file_name>.txt . Where scheduler_type is either "slurm" or "pbs".
 
 For `ClusterInitSpec`definition use thie following format, and make sure to use the same spec name in the projects dictionary
 ```json

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ This describes the CycleCloud clusters configuration and projects to be uploaded
 This describes the template and parameters to be applied on a CycleCloud cluster.
 | Name       | Description                                                                          | Required | Default |
 |------------|--------------------------------------------------------------------------------------|----------|---------|
-| **template** | The name of the template used to create the cluster.                                                         |   yes    |         |
+| **template** | The name of the template or template file used to create the cluster.              |   yes    |         |
 | **parameters** | Dictionary of parameters defined in the template. The parameter list can be retrieved with the [cyclecloud export_parameters](https://docs.microsoft.com/en-us/azure/cyclecloud/cli?view=cyclecloud-7#cyclecloud-export_parameters) command |   yes    |         |
 
 For `ClusterInitSpec`definition use thie following format, and make sure to use the same spec name in the projects dictionary


### PR DESCRIPTION
- Added support to create a cyclecloud cluster with a customized template file.

If the cyclecloud parameter "template" (in the config.json file) is set to the name of a cyclecloud text template file, it will use that to create the cyclecloud cluster (instead of a built-in cyclecloud template).

"template" : <"Name of the cyclecloud template file">

The format of the template file is <Scheduler_type>_<file_name>.txt
where scheduler can be "pbs" or "slurm". (e.g slurm_ndv4.txt)