### PR TITLE
CC_SLURM_NHC (Changed NHC defaults)

### DIFF
--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/configure_nhc.sh
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/configure_nhc.sh
@@ -6,12 +6,12 @@ NHC_TIMEOUT=200
 NHC_VERBOSE=1
 NHC_DETACHED_MODE=1
 NHC_DEBUG=0
-NHC_CONF_FILE_NEW=$CYCLECLOUD_SPEC_PATH/files/nd96asr_v4.conf
+NHC_CONF_FILE_NEW=$CYCLECLOUD_SPEC_PATH/files/nd96amsr_v4.conf
 NHC_EXE=/usr/sbin/nhc
 NHC_NVIDIA_HEALTHMON=dcgmi
 NHC_NVIDIA_HEALTHMON_ARGS="diag -r 1"
 SLURM_CONF=/etc/slurm/slurm.conf
-SLURM_HEALTH_CHECK_INTERVAL=200
+SLURM_HEALTH_CHECK_INTERVAL=1200
 SLURM_HEALTH_CHECK_NODE_STATE=IDLE
 NHC_EXTRA_TEST_FILES="csc_nvidia_smi.nhc azure_cuda_bandwidth.nhc azure_gpu_app_clocks.nhc azure_gpu_ecc.nhc azure_gpu_persistence.nhc azure_ib_write_bw_gdr.nhc azure_nccl_allreduce_ib_loopback.nhc azure_ib_link_flapping.nhc azure_gpu_clock_throttling.nhc"
 

--- a/experimental/cc_slurm_nhc/readme.md
+++ b/experimental/cc_slurm_nhc/readme.md
@@ -11,7 +11,7 @@ is created to allow this healthcheck framework to be integrated in CycleCloud SL
 - Compute node(s), ND96asr_v4 or ND96amsr_v4 (Running Ubuntu-hpc 18.04)
 
 ## Design
-The Node health checks only run on IDLE SLURM nodes (not on nodes with running jobs). If a node healthcheck fails, the node will be put into a DRAIN state (All jobs using this node will be allowed to complete, but not new jobs will use this node). If the issue that caused the healthcheck to fail is resolved, the net time the node health check is run the node will be move from the DRAIN state to the IDLE state, and will now be ready to accept new jobs. This example contains an example node check for ND96asr_v4 (nd96asr_v4.conf), it should be relatively easy to create similar configuration files for other specialty SKU's like HBv3,HBv2 and HC, and run health checks for those SKU's also using this framework.
+The Node health checks only run on IDLE SLURM nodes (not on nodes with running jobs). If a node healthcheck fails, the node will be put into a DRAIN state (All jobs using this node will be allowed to complete, but not new jobs will use this node). If the issue that caused the healthcheck to fail is resolved, the net time the node health check is run the node will be move from the DRAIN state to the IDLE state, and will now be ready to accept new jobs. This example contains an example node check for ND96amsr_v4 (nd96amsr_v4.conf), it should be relatively easy to create similar configuration files for other specialty SKU's like HBv3,HBv2 and HC, and run health checks for those SKU's also using this framework.
 
 ## What health checks are performed?
 
@@ -50,7 +50,7 @@ See in the CC Portal Edit-->Advanced-Settings, under Software. Also, added the f
 ```
 SuspendExcParts=hpc
 HealthCheckProgram=/usr/sbin/nhc
-HealthCheckInterval=200
+HealthCheckInterval=1200
 HealthCheckNodeState=IDLE
 ```
 >Note: In my case I am disabling autoscaling (SuspendExcParts=hpc), if you have autoscaling enabled you may need to modify these scripts to prevent the 


### PR DESCRIPTION
-Use NHC configuration file ND96amsr_v4 (80GB A100), by default.
-Increased time interval between NHC tests.
-Updated readme file