### PR TITLE
Fix NHC GPU application clocks script to iterate across all GPUs

### DIFF
--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/azure_gpu_app_clocks.nhc
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/azure_gpu_app_clocks.nhc
@@ -38,10 +38,9 @@ function check_app_gpu_clocks() {
             die 1 "$FUNCNAME: nvidia-smi (set gpu max clock freqs) returned error code $set_gpu_freq_out_rc"
          fi
          log "On GPU Id $i: $set_gpu_freq_out"
-	 return 0
       else
          dbg "GPU Id $i: max application GPU clocks are already set, GPU memory is  ${gpu_freq_out_line[0]} MHz and GPU graphics is ${gpu_freq_out_line[2]} MHz"
-	 return 0
       fi
 done
+return 0
 }


### PR DESCRIPTION
The return statements in the `azure_gpu_app_clocks.nhc` script stop the loop at the first iteration, causing only GPU #0 to have the correct max application frequency to be correct.