### PR TITLE
CC_SLURM_NHC (Support dropping CPU cached memory.)

### DIFF
--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/azure_cpu_drop_cache_mem.nhc
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/azure_cpu_drop_cache_mem.nhc
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Check size of cached CPU memory, if large than <CPU_CACHED_MEM_KB> argument then drop the memory caches.
+
+
+function collect_cached_cpu_memory_data() {
+
+   meminfo_out=$(cat /proc/meminfo)
+   meminfo_out_rc=$?
+   if [[ $meminfo_out_rc != 0 ]]; then
+     log "$meminfo_out"
+     die 1 "$FUNCNAME: Does /proc/meminfo exist, returned error code $meminfo_out_rc"
+   fi
+   IFS=$'\n'
+   meminfo_lines=( $meminfo_out )
+   IFS=$' \t\n'
+}
+
+function find_cpu_cached_mem() {
+
+   for ((i=0; i<${#meminfo_lines[*]}; i++))
+   do
+      if [[ "${meminfo_lines[$i]//Cached}" != "${meminfo_lines[$i]}" ]]
+      then
+         IFS=$' \t\n'
+         line=( ${meminfo_lines[$i]} )
+         echo "${line[1]}"
+      fi
+   done
+}
+
+
+function check_cpu_drop_mem_cache() {
+
+   collect_cached_cpu_memory_data
+
+   CPU_CACHED_MEM_KB=$1
+   dbg "CPU_CACHED_MEM_KB=$CPU_CACHED_MEM_KB KB"
+   if [[ -n $CPU_CACHED_MEM_KB ]]; then
+           current_cpu_cached_mem_kb=$(find_cpu_cached_mem)
+           dbg "current_cpu_cached_mem_kb=$current_cpu_cached_mem_kb KB"
+           if [[ $current_cpu_cached_mem_kb > $CPU_CACHED_MEM_KB ]]; then
+              dbg "$FUNCNAME: We will attempt to drop the cpu memory cache"
+              cpu_drop_mem_cache_out=$(sync;echo 3 > /proc/sys/vm/drop_caches)
+              cpu_drop_mem_cache_out_rc=$?
+              if [[ $cpu_drop_mem_cache_out_rc != 0 ]]; then
+                 log "$cpu_drop_mem_cache_out"
+                 die 1 "$FUNCNAME: Could not drop the cpu memory cache, returned error code $cpu_drop_mem_cache_out_rc"
+              else
+                 log "Dropped the CPU memory cache successfully"
+              fi
+           fi
+   else
+      dbg "$FUNCNAME: Will not check the CPU cached memory, (CPU_CACHED_MEM_KB argument is not set)"
+   fi
+   return 0
+}

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/configure_nhc.sh
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/configure_nhc.sh
@@ -16,7 +16,7 @@ NHC_NVIDIA_HEALTHMON_ARGS="diag -r 1"
 SLURM_CONF=/etc/slurm/slurm.conf
 SLURM_HEALTH_CHECK_INTERVAL=7200
 SLURM_HEALTH_CHECK_NODE_STATE=IDLE
-NHC_EXTRA_TEST_FILES="csc_nvidia_smi.nhc azure_cuda_bandwidth.nhc azure_gpu_app_clocks.nhc azure_gpu_ecc.nhc azure_gpu_persistence.nhc azure_ib_write_bw_gdr.nhc azure_nccl_allreduce_ib_loopback.nhc azure_ib_link_flapping.nhc azure_gpu_clock_throttling.nhc"
+NHC_EXTRA_TEST_FILES="csc_nvidia_smi.nhc azure_cuda_bandwidth.nhc azure_gpu_app_clocks.nhc azure_gpu_ecc.nhc azure_gpu_persistence.nhc azure_ib_write_bw_gdr.nhc azure_nccl_allreduce_ib_loopback.nhc azure_ib_link_flapping.nhc azure_gpu_clock_throttling.nhc azure_cpu_drop_cache_mem.nhc"
 
 
 function select_sku_conf() {

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/hb120-16rs_v3.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/hb120-16rs_v3.conf
@@ -123,3 +123,10 @@
  * || check_ps_service -S -u root sshd
  * || check_ps_service -r -d rpc.statd nfslock
  * || check_ps_service -S -d rsyslogd -u root rsyslog
+
+
+#######################################################################
+####
+#### Additional memory checks
+####
+ * || check_cpu_drop_mem_cache 1000000

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/hb120-32rs_v3.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/hb120-32rs_v3.conf
@@ -123,3 +123,10 @@
  * || check_ps_service -S -u root sshd
  * || check_ps_service -r -d rpc.statd nfslock
  * || check_ps_service -S -d rsyslogd -u root rsyslog
+
+
+#######################################################################
+####
+#### Additional memory checks
+####
+ * || check_cpu_drop_mem_cache 1000000

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/hb120-64rs_v3.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/hb120-64rs_v3.conf
@@ -123,3 +123,10 @@
  * || check_ps_service -S -u root sshd
  * || check_ps_service -r -d rpc.statd nfslock
  * || check_ps_service -S -d rsyslogd -u root rsyslog
+
+
+#######################################################################
+####
+#### Additional memory checks
+####
+ * || check_cpu_drop_mem_cache 1000000

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/hb120-96rs_v3.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/hb120-96rs_v3.conf
@@ -123,3 +123,10 @@
  * || check_ps_service -S -u root sshd
  * || check_ps_service -r -d rpc.statd nfslock
  * || check_ps_service -S -d rsyslogd -u root rsyslog
+
+
+#######################################################################
+####
+#### Additional memory checks
+####
+ * || check_cpu_drop_mem_cache 1000000

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/hb120rs_v3.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/hb120rs_v3.conf
@@ -123,3 +123,10 @@
  * || check_ps_service -S -u root sshd
  * || check_ps_service -r -d rpc.statd nfslock
  * || check_ps_service -S -d rsyslogd -u root rsyslog
+
+
+#######################################################################
+####
+#### Additional memory checks
+####
+ * || check_cpu_drop_mem_cache 1000000

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96amsr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96amsr_v4.conf
@@ -146,3 +146,10 @@
 * || check_ib_bw_gdr 185.0
 * || check_nccl_allreduce_ib_loopback 18.0
 * || check_ib_link_flapping 6
+
+
+#######################################################################
+####
+#### Additional memory checks
+####
+ * || check_cpu_drop_mem_cache 1000000

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
@@ -144,3 +144,10 @@
  * || check_ib_bw_gdr 185.0
  * || check_nccl_allreduce_ib_loopback 18.0
  * || check_ib_link_flapping 6
+
+
+#######################################################################
+####
+#### Additional memory checks
+####
+ * || check_cpu_drop_mem_cache 1000000

--- a/experimental/cc_slurm_nhc/readme.md
+++ b/experimental/cc_slurm_nhc/readme.md
@@ -32,6 +32,7 @@ The nd96asr_v4.conf and nd96amsr_v4.conf nhc configuration file specifies what h
 * Check NCCL allreduce IB loopback bandwidth performance
 * Check for IB link flapping
 * Check for GPU clock throttling
+* Check if should drop CPU cached memory
 
 Will continue to add additional tests.
 


### PR DESCRIPTION
-Add check to see if CPU cached memory should be dropped. If cached memory is about a set threshold, an
attempt is made to drop the cache to clean up the memory.