### PR TITLE
Support running cyclecloud project scripts in the background

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,11 +274,12 @@ For `ClusterInitSpec`definition use thie following format, and make sure to use 
 This describes the CycleCloud project containing cluster-init wrapper scripts to be uploaded in the CycleCloud locker. 
 Each project name has to follow the CycleCloud naming convention `projectname:specname:i.j.k` and contains an array of scripts described below :
 
-| Name       | Description                                                                          | Required | Default |
-|------------|--------------------------------------------------------------------------------------|----------|---------|
-| **script** | The name of the script to run                                                        |   yes    |         |
-| **deps**   | A list of dependent files                                                            |   no     |         |
-| **args**   | A list containing the arguments for the script                                       |   no     |         |
+| Name             | Description                                                                          | Required | Default |
+|------------------|--------------------------------------------------------------------------------------|----------|---------|
+| **script**       | The name of the script to run                                                        |   yes    |         |
+| **deps**         | A list of dependent files                                                            |   no     |         |
+| **args**         | A list containing the arguments for the script                                       |   no     |         |
+| **background**   | Run **script** in the background (true,false)                                        |   no     |  false  |
 
 
 ### Macros in the config file

--- a/pyazhpc/azinstall.py
+++ b/pyazhpc/azinstall.py
@@ -369,6 +369,7 @@ name = {project}
         for idx, step in enumerate(config["cyclecloud"]["projects"][p]):
             script = step["script"]
             script_file = f"{scripts_dir}/{idx:02d}_{script}"
+            background = step.get("background", None)
 
             # copy script file and dependencies into files_dir
             for s in [ script ] + step.get("deps", []):
@@ -376,7 +377,13 @@ name = {project}
 
             # create cluster-init script
             args = " ".join([ f'"{arg}"' for arg in step.get("args", []) ])
-            script_content = f"""#!/bin/bash
+            if background:
+               script_content = f"""#!/bin/bash
+chmod +x $CYCLECLOUD_SPEC_PATH/files/*.sh
+$CYCLECLOUD_SPEC_PATH/files/{script} {args} &
+"""
+            else:
+               script_content = f"""#!/bin/bash
 chmod +x $CYCLECLOUD_SPEC_PATH/files/*.sh
 $CYCLECLOUD_SPEC_PATH/files/{script} {args}
 """


### PR DESCRIPTION
Add support for running a cyclecloud project script in the background.

New "background" parameter (true or false) (default is false)

"cyclecloud project name": {
   {
     "script": script_name
    "background": true
   }
}