### PR TITLE
CC_SLURM_NHC (DRAIN nodes if ECC error count > 20M)

### DIFF
--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/azure_gpu_ecc.nhc
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/azure_gpu_ecc.nhc
@@ -65,7 +65,7 @@ function check_gpu_ecc() {
       fi
       if [[ -n $1 ]]; then
          if [[ ${gpu_query_out_line[2]} -gt $1 || ${gpu_query_out_line[3]} -gt $1 || ${gpu_query_out_line[6]} -gt $1 || ${gpu_query_out_line[7]} -gt $1 ]]; then
-	    log "Warning: $FUNCNAME: GPU id $i: High DRAM Uncorrectable/correctable ECC error count detected, (${gpu_query_out_line[2]},${gpu_query_out_line[3]},${gpu_query_out_line[6]},${gpu_query_out_line[7]})"
+	    die 1 "$FUNCNAME: GPU id $i: High DRAM Uncorrectable/correctable ECC error count detected, (${gpu_query_out_line[2]},${gpu_query_out_line[3]},${gpu_query_out_line[6]},${gpu_query_out_line[7]})"
          else
             dbg "GPU id $i: Normal DRAM Uncorrectable/correctable ECC error count, (${gpu_query_out_line[2]},${gpu_query_out_line[3]},${gpu_query_out_line[6]},${gpu_query_out_line[7]})"
          fi

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96amsr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96amsr_v4.conf
@@ -135,7 +135,7 @@
  * || check_nv_healthmon
  * || check_cuda_bw 24.0 3
  * || check_app_gpu_clocks
- * || check_gpu_ecc 10000000
+ * || check_gpu_ecc 20000000
  * || check_gpu_clock_throttling
 
 

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
@@ -133,7 +133,7 @@
  * || check_nv_healthmon
  * || check_cuda_bw 24.0 3
  * || check_app_gpu_clocks
- * || check_gpu_ecc 10000000
+ * || check_gpu_ecc 20000000
  * || check_gpu_clock_throttling
 
 


### PR DESCRIPTION
- Changed the high ECC error count default to be 20M
-  If ECC error count exceeds the count threshold (default 20M), not will be put into a DRAIN state (instead of just issuing a warning)