### PR TITLE
Harden scripts sourcing common_function.sh

### DIFF
--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/build_bandwidthtest.sh
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/build_bandwidthtest.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source common_functions.sh
+source $CYCLECLOUD_SPEC_PATH/files/common_functions.sh
 
 if ! is_slurm_controller; then
    cd /usr/local/cuda/samples/1_Utilities/bandwidthTest

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/build_perftest_gdr.sh
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/build_perftest_gdr.sh
@@ -4,7 +4,7 @@ VERSION=4.5-0.12
 VERSION_HASH=ge93c538
 INSTALL_DIR=/opt
 
-source common_functions.sh
+source $CYCLECLOUD_SPEC_PATH/files/common_functions.sh
 
 if ! is_slurm_controller; then
    apt-get install -y pciutils-dev

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/configure_nhc.sh
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/configure_nhc.sh
@@ -20,7 +20,7 @@ NHC_PROLOG=1
 NHC_EPILOG=0
 NHC_EXTRA_TEST_FILES="csc_nvidia_smi.nhc azure_cuda_bandwidth.nhc azure_gpu_app_clocks.nhc azure_gpu_ecc.nhc azure_gpu_persistence.nhc azure_ib_write_bw_gdr.nhc azure_nccl_allreduce_ib_loopback.nhc azure_ib_link_flapping.nhc azure_gpu_clock_throttling.nhc azure_cpu_drop_cache_mem.nhc"
 
-source common_functions.sh
+source $CYCLECLOUD_SPEC_PATH/files/common_functions.sh
 
 function select_sku_conf() {
    vm_size=`jetpack config azure.metadata.compute.vmSize | tr '[:upper:]' '[:lower:]'`

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/install_nhc.sh
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/install_nhc.sh
@@ -7,7 +7,7 @@ TMPDIR=/tmp
 TAR_FILE=$CYCLECLOUD_SPEC_PATH/files/
 
 
-source common_functions.sh
+source $CYCLECLOUD_SPEC_PATH/files/common_functions.sh
 
 
 function get_source() {

--- a/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/configure_pyxis.sh
+++ b/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/configure_pyxis.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source common_functions.sh
+source $CYCLECLOUD_SPEC_PATH/files/common_functions.sh
 
 function link_plugstack() {
    ln -s /sched/plugstack.conf /etc/slurm/plugstack.conf

--- a/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/install_enroot.sh
+++ b/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/install_enroot.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source common_functions.sh
+source $CYCLECLOUD_SPEC_PATH/files/common_functions.sh
 
 ENROOT_VERSION_FULL=${1:-3.4.0-1}
 ENROOT_VERSION=${ENROOT_VERSION_FULL%-*}

--- a/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/install_enroot_hooks.sh
+++ b/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/install_enroot_hooks.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source common_functions.sh
+source $CYCLECLOUD_SPEC_PATH/files/common_functions.sh
 
 # Install extra hooks for PMIx on compute nodes
 if ! is_slurm_controller; then

--- a/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/install_pyxis.sh
+++ b/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/install_pyxis.sh
@@ -4,7 +4,7 @@ PYXIS_VER=0.11.1
 TMP_DIR=/tmp
 SHARED_DIR=/sched/pyxis
 
-source common_functions.sh
+source $CYCLECLOUD_SPEC_PATH/files/common_functions.sh
 
 function install_build_deps() {
    apt-get -y install gcc make

--- a/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/slurmd_pmix.sh
+++ b/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/slurmd_pmix.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source common_functions.sh
+source $CYCLECLOUD_SPEC_PATH/files/common_functions.sh
 
 if ! is_slurm_controller; then
 while [ ! -f /etc/sysconfig/slurmd ]


### PR DESCRIPTION
Source common_function.sh from CC spec dir.
This prevent errors if the file is not correctly copied where the calling script is located.