### PR TITLE
Fix CycleCLI installation in local host

### DIFF
--- a/scripts/cyclecli_install.sh
+++ b/scripts/cyclecli_install.sh
@@ -41,6 +41,8 @@ install_cli8()
     pushd cyclecloud-cli-installer/
 
     echo "Installing CLI..."
+    # Unset PYTHONPATH set by AzureHPC
+    unset PYTHONPATH
     # If az CLI is installed used the bundled version
     python_path=$(az --version | grep 'Python location' | xargs | cut -d' ' -f3)
     if [ -n "$python_path" ]; then


### PR DESCRIPTION
AzureHPC sets `PYTHONPATH=$AZHPC_PYTHONPATH`.
This interferes with the CycleCLI `install.py` when running `cyclecli_install.sh` locally. The result is that required dependencies (e.g. six) are not installed in `$HOME/.cycle/cli/lib64/python3.6/site-packages` as expected by `cyclecloud`.