### PR TITLE
CC_SLURM_NHC (Added SRAM correctable ECC threshold)

### DIFF
--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/azure_gpu_ecc.nhc
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/azure_gpu_ecc.nhc
@@ -33,6 +33,9 @@ function check_gpu_ecc() {
 
    collect_ecc_data
 
+   ecc_error_threshold=$1
+   ecc_sram_threshold=$2
+
    if [[ ${#gpu_query_out_lines[*]} != ${#gpu_remapped_rows_query_out_lines[*]} ]]; then
       die 1 "$FUNCNAME: nvidia-smi (Number GPU's not correct), (${#gpu_query_out_lines[*]},${#gpu_remapped_rows_query_out_lines[*]})"
    fi
@@ -58,18 +61,20 @@ function check_gpu_ecc() {
          die 1 "$FUNCNAME: GPU id $i: Row remap uncorrectable error count is too high"
       fi
       dbg "GPU id $i: No GPU row remap pending, row remap errors or row remap high count errors"
-      if [[ ${gpu_query_out_line[0]} -gt 0 || ${gpu_query_out_line[1]} -gt 0 || ${gpu_query_out_line[4]} -gt 0 || ${gpu_query_out_line[5]} -gt 0 ]]; then
-         die 1 "$FUNCNAME: GPU id $i: SRAM Uncorrectable/correctable ECC error count detected"
+      if [[ ${gpu_query_out_line[4]} -gt $ecc_sram_threshold || ${gpu_query_out_line[5]} -gt $ecc_sram_threshold ]]; then
+         die 1 "$FUNCNAME: GPU id $i: High SRAM correctable ECC error count detected, (${gpu_query_out_line[4]},${gpu_query_out_line[5]})"
+      elif [[ ${gpu_query_out_line[0]} -gt 0 || ${gpu_query_out_line[1]} -gt 0 ]]; then
+         die 1 "$FUNCNAME: GPU id $i: SRAM Uncorrectable ECC error count detected, (${gpu_query_out_line[0]},${gpu_query_out_line[1]})"
       else
          dbg "GPU id $i: Normal SRAM Uncorrectable/correctable ECC error count, (${gpu_query_out_line[0]},${gpu_query_out_line[1]},${gpu_query_out_line[4]},${gpu_query_out_line[5]})"
       fi
-      if [[ -n $1 ]]; then
-         if [[ ${gpu_query_out_line[2]} -gt $1 || ${gpu_query_out_line[3]} -gt $1 || ${gpu_query_out_line[6]} -gt $1 || ${gpu_query_out_line[7]} -gt $1 ]]; then
+      if [[ -n $ecc_error_threshold ]]; then
+         if [[ ${gpu_query_out_line[2]} -gt $ecc_error_threshold || ${gpu_query_out_line[3]} -gt $ecc_error_threshold || ${gpu_query_out_line[6]} -gt $ecc_error_threshold || ${gpu_query_out_line[7]} -gt $ecc_error_threshold ]]; then
 	    die 1 "$FUNCNAME: GPU id $i: High DRAM Uncorrectable/correctable ECC error count detected, (${gpu_query_out_line[2]},${gpu_query_out_line[3]},${gpu_query_out_line[6]},${gpu_query_out_line[7]})"
          else
             dbg "GPU id $i: Normal DRAM Uncorrectable/correctable ECC error count, (${gpu_query_out_line[2]},${gpu_query_out_line[3]},${gpu_query_out_line[6]},${gpu_query_out_line[7]})"
          fi
       fi
-done
+   done
 return 0
 }

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96amsr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96amsr_v4.conf
@@ -135,7 +135,7 @@
  * || check_nv_healthmon
  * || check_cuda_bw 24.0 3
  * || check_app_gpu_clocks
- * || check_gpu_ecc 20000000
+ * || check_gpu_ecc 20000000 10000
  * || check_gpu_clock_throttling
  * || check_gpu_xid
 

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
@@ -133,7 +133,7 @@
  * || check_nv_healthmon
  * || check_cuda_bw 24.0 3
  * || check_app_gpu_clocks
- * || check_gpu_ecc 20000000
+ * || check_gpu_ecc 20000000 10000
  * || check_gpu_clock_throttling
  * || check_gpu_xid
 


### PR DESCRIPTION
Modified the GPU ECC error count check, added a SRAM correctable ECC threshold (set to 10k in nhc configuration files).

An SRAM correctable ECC error check will only fail if the count exceeds the threshold (10k).

NHC config file
 * || check_gpu_ecc 10000000 **10000**
