### PR TITLE
Add peering gateway opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,26 @@ The config file will create or reuse vnet and subnets from the config file.
 
 This dictionary describes the virtual network peering to be created
 
-| Name               | Description                                                                        | Required | Default |
-|--------------------|------------------------------------------------------------------------------------|----------|---------|
-| **resource_group** | Name of the resource group containing the vnet to peer to                          |   yes    |         |
-| **vnet_name**      | Name of the vnet to peer to                                                        |   yes    |         |
+| Name                             | Description                                                          | Required | Default |
+|----------------------------------|----------------------------------------------------------------------|----------|---------|
+| **resource_group**               | Name of the resource group containing the vnet to peer to            |   yes    |         |
+| **vnet_name**                    | Name of the vnet to peer to                                          |   yes    |         |
+| **peer_allow_vnet_access**       | Allow traffic from peer network to vnet                              |   no     | True    |
+| **peer_allow_forwarded_traffic** | Allow traffic forwarded from vnet to peer network                    |   no     | True    |
+| **vnet_allow_vnet_access**       | Allow traffic from vnet to peer virtual network                      |   no     | True    |
+| **vnet_allow_forwarded_traffic** | Allow traffic to be forwarded from peer virtual network to vnet      |   no     | True    |
+| **gateway**                      | Dictionary of [peer-gateway](#peer-gateway-dictionary) to create     |   no     |         |
+
+This dictionary describes the configuration of virtual nework gateway used in the peering
+
+##### Peer-Gateway dictionary
+
+| Name                           | Description                                                            | Required | Default |
+|--------------------------------|------------------------------------------------------------------------|----------|---------|
+| **peer_allow_gateway_transit** | Use the peer's gateway server                                          |   no     | False   |
+| **peer_allow_remote_gateways** | Use the vnet's gateway server                                          |   no     | False   |
+| **vnet_allow_gateway_transit** | Use the vnet's gateway server                                          |   no     | False   |
+| **vnet_allow_remote_gateways** | Use the peer's gateway server                                          |   no     | False   |
 
 #### Route dictionary
 
@@ -135,6 +151,33 @@ Here is an example setup with four subnets:
         "viz": "10.2.2.0/24",
         "storage": "10.2.3.0/24",
         "compute": "10.2.4.0/22"
+    }
+},
+...
+```
+
+An example creating a new virtual network *new-vnet* with peering to an existing network *old-vnet* with a virtual network gateway which it will
+use
+
+```json
+...
+"vnet": {
+    "name": "new-vnet",
+    "resource_group": "new-vnet-rg",
+    "address_prefix": "10.11.0.0/20",
+    "subnets": {
+        "default": "10.11.1.0/24",
+        "data": "10.11.2.0/24"
+    },
+    "peer": {
+        "old-vnet": {
+            "resource_group": "old-rg",
+            "vnet_name": "old-vnet",
+            "gateway": {
+                "peer_use_remote_gateways": true,
+                "vnet_allow_gateway_transit": true
+            }
+        }
     }
 },
 ...

--- a/pyazhpc/arm.py
+++ b/pyazhpc/arm.py
@@ -60,6 +60,21 @@ class ArmTemplate:
         for peer_name in cfg["vnet"].get("peer", {}).keys():
             peer_resource_group = cfg["vnet"]["peer"][peer_name]["resource_group"]
             peer_vnet_name = cfg["vnet"]["peer"][peer_name]["vnet_name"]
+            peer_allow_vnet_access = cfg["vnet"]["peer"][peer_name].get("peer_allow_vnet_access", True)
+            peer_allow_forwarded_traffic = cfg["vnet"]["peer"][peer_name].get("peer_allow_forwarded_traffic", True)
+            vnet_allow_vnet_access = cfg["vnet"]["peer"][peer_name].get("vnet_allow_vnet_access", True)
+            vnet_allow_forwarded_traffic = cfg["vnet"]["peer"][peer_name].get("vent_allow_forwarded_traffic", True)
+
+            if "gateway" in cfg["vnet"]["peer"][peer_name]:
+                peer_allow_gateway_transit = cfg["vnet"]["peer"][peer_name]["gateway"].get("peer_allow_gateway_transit", False)
+                peer_use_remote_gateways = cfg["vnet"]["peer"][peer_name]["gateway"].get("peer_use_remote_gateways", False)
+                vnet_allow_gateway_transit = cfg["vnet"]["peer"][peer_name]["gateway"].get("vnet_allow_gateway_transit", False)
+                vnet_use_remote_gateways = cfg["vnet"]["peer"][peer_name]["gateway"].get("vnet_use_remote_gateways", False)
+            else:
+                peer_allow_gateway_transit = False
+                peer_use_remote_gateways = False
+                vnet_allow_gateway_transit = False
+                vnet_use_remote_gateways = False
 
             self.resources.append({
                 "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
@@ -69,10 +84,10 @@ class ArmTemplate:
                     "remoteVirtualNetwork": {
                         "id": f"[resourceId('{peer_resource_group}', 'Microsoft.Network/virtualNetworks', '{peer_vnet_name}')]"
                     },
-                    "allowVirtualNetworkAccess": True,
-                    "allowForwardedTraffic": True,
-                    "allowGatewayTransit": False,
-                    "useRemoteGateways": False,
+                    "allowVirtualNetworkAccess": peer_allow_vnet_access,
+                    "allowForwardedTraffic": peer_allow_forwarded_traffic,
+                    "allowGatewayTransit": peer_allow_gateway_transit,
+                    "useRemoteGateways": peer_use_remote_gateways
                 },
                 "dependsOn": [
                     f"Microsoft.Network/virtualNetworks/{vnet_name}"
@@ -101,10 +116,10 @@ class ArmTemplate:
                                     "remoteVirtualNetwork": {
                                         "id": f"[resourceId('{resource_group}', 'Microsoft.Network/virtualNetworks', '{vnet_name}')]"
                                     },
-                                    "allowVirtualNetworkAccess": True,
-                                    "allowForwardedTraffic": True,
-                                    "allowGatewayTransit": False,
-                                    "useRemoteGateways": False
+                                    "allowVirtualNetworkAccess": vnet_allow_vnet_access,
+                                    "allowForwardedTraffic": vnet_allow_forwarded_traffic,
+                                    "allowGatewayTransit": vnet_allow_gateway_transit,
+                                    "useRemoteGateways": vnet_use_remote_gateways
                                 }
                             }
                         ],

--- a/pyazhpc/azutil.py
+++ b/pyazhpc/azutil.py
@@ -30,6 +30,19 @@ def delete_resources(ids):
         sys.exit(1)
     return res.stdout
 
+def delete_vnet_peering(resource_group, peering_name, vnet_name):
+    cmd = [
+        "az", "network", "vnet", "peering", "delete",
+            "--resource-group", resource_group,
+            "--name", peering_name,
+            "--vnet-name", vnet_name
+    ]
+    res = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if res.returncode != 0:
+        log.error("invalid returncode"+_make_subprocess_error_string(res))
+        sys.exit(1)
+    return res.stdout
+
 def get_vm_private_ip(resource_group, vm_name):
     cmd = [
         "az", "vm", "list-ip-addresses",
@@ -123,7 +136,6 @@ def delete_resource_group(resource_group, nowait):
         log.error("invalid returncode"+_make_subprocess_error_string(res))
         sys.exit(1)
 
-
 def deploy(resource_group, arm_template):
     log.debug("deploying template")
     deployname = os.path.splitext(
@@ -205,7 +217,7 @@ def get_storage_key(account):
 def get_storage_saskey(account, container, permissions, duration="2h"):
     log.debug(f"creating sas key: container={container}, permissions={permissions}, length={duration}")
     start = (datetime.datetime.utcnow() - datetime.timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
-    
+
     # convert integer string to int type
     length = int(duration[:-1])
     unit = duration[-1]


### PR DESCRIPTION
    Expose additional peering configuration options to eliminate need to manually configure peering with existing vnets.
    
    - Add config dictionary in ['vnet']['peer'] for gateway options
    - Add config fields in ['vnet']['peer'][<peer-name>] for traffic options
    - Add method to delete peerings with azhpc-destroy when defined in config.json
    - Default configs remain unchanged
    - Update to README.md to reflect changes with example of adding peering