### PR TITLE
Disable Ubuntu unattended upgrades

### DIFF
--- a/experimental/deploy_cycle_slurm_ndv4/config.json
+++ b/experimental/deploy_cycle_slurm_ndv4/config.json
@@ -191,9 +191,9 @@
           "SchedulerClusterInitSpecs": {
             "misc_ubuntu:default:1.0.0": {
               "Order": 10000,
-              "Name": "limits:default:1.0.0",
+              "Name": "misc_ubuntu:default:1.0.0",
               "Spec": "default",
-              "Project": "limits",
+              "Project": "misc_ubuntu",
               "Version": "1.0.0",
               "Locker": "azure-storage"
             }
@@ -209,9 +209,9 @@
             },
             "misc_ubuntu:default:1.0.0": {
               "Order": 10010,
-              "Name": "limits:default:1.0.0",
+              "Name": "misc_ubuntu:default:1.0.0",
               "Spec": "default",
-              "Project": "limits",
+              "Project": "misc_ubuntu",
               "Version": "1.0.0",
               "Locker": "azure-storage"
             }

--- a/experimental/deploy_cycle_slurm_ndv4/config.json
+++ b/experimental/deploy_cycle_slurm_ndv4/config.json
@@ -188,10 +188,27 @@
           "loginMachineType": "variables.login_vm_type",
           "HPCMaxScalesetSize": 100,
           "additional_slurm_config": "SuspendTime=-1",
-          "SchedulerClusterInitSpecs": {},
+          "SchedulerClusterInitSpecs": {
+            "misc_ubuntu:default:1.0.0": {
+              "Order": 10000,
+              "Name": "limits:default:1.0.0",
+              "Spec": "default",
+              "Project": "limits",
+              "Version": "1.0.0",
+              "Locker": "azure-storage"
+            }
+          },
           "LoginClusterInitSpecs": {
             "limits:default:1.0.0": {
               "Order": 10000,
+              "Name": "limits:default:1.0.0",
+              "Spec": "default",
+              "Project": "limits",
+              "Version": "1.0.0",
+              "Locker": "azure-storage"
+            },
+            "misc_ubuntu:default:1.0.0": {
+              "Order": 10010,
               "Name": "limits:default:1.0.0",
               "Spec": "default",
               "Project": "limits",
@@ -279,9 +296,14 @@
         }
       ],
       "limits:default:1.0.0": [
-                      {
-                        "script": "set_limits.sh"
-                      }
+        {
+          "script": "set_limits.sh"
+        }
+      ],
+      "misc_ubuntu:default:1.0.0": [
+        {
+          "script": "disable_unattended_upgrades.sh"
+        }
       ]
     }
   }

--- a/experimental/deploy_cycle_slurm_ndv4/config_pyxis_enroot.json
+++ b/experimental/deploy_cycle_slurm_ndv4/config_pyxis_enroot.json
@@ -207,9 +207,9 @@
             },
             "misc_ubuntu:default:1.0.0": {
               "Order": 10020,
-              "Name": "limits:default:1.0.0",
+              "Name": "misc_ubuntu:default:1.0.0",
               "Spec": "default",
-              "Project": "limits",
+              "Project": "misc_ubuntu",
               "Version": "1.0.0",
               "Locker": "azure-storage"
             }
@@ -225,9 +225,9 @@
             },
             "misc_ubuntu:default:1.0.0": {
               "Order": 10010,
-              "Name": "limits:default:1.0.0",
+              "Name": "misc_ubuntu:default:1.0.0",
               "Spec": "default",
-              "Project": "limits",
+              "Project": "misc_ubuntu",
               "Version": "1.0.0",
               "Locker": "azure-storage"
             }

--- a/experimental/deploy_cycle_slurm_ndv4/config_pyxis_enroot.json
+++ b/experimental/deploy_cycle_slurm_ndv4/config_pyxis_enroot.json
@@ -190,7 +190,7 @@
           "additional_slurm_config": "SuspendTime=-1",
           "SchedulerClusterInitSpecs": {
             "slurm_pyxis_enroot:default:1.0.0": {
-              "Order": 10020,
+              "Order": 10000,
               "Name": "slurm_pyxis_enroot:default:1.0.0",
               "Spec": "default",
               "Project": "slurm_pyxis_enroot",
@@ -198,10 +198,18 @@
               "Locker": "azure-storage"
             },
             "nhc:default:1.0.0": {
-              "Order": 10030,
+              "Order": 10010,
               "Name": "nhc:default:1.0.0",
               "Spec": "default",
               "Project": "nhc",
+              "Version": "1.0.0",
+              "Locker": "azure-storage"
+            },
+            "misc_ubuntu:default:1.0.0": {
+              "Order": 10020,
+              "Name": "limits:default:1.0.0",
+              "Spec": "default",
+              "Project": "limits",
               "Version": "1.0.0",
               "Locker": "azure-storage"
             }
@@ -209,6 +217,14 @@
           "LoginClusterInitSpecs": {
             "limits:default:1.0.0": {
               "Order": 10000,
+              "Name": "limits:default:1.0.0",
+              "Spec": "default",
+              "Project": "limits",
+              "Version": "1.0.0",
+              "Locker": "azure-storage"
+            },
+            "misc_ubuntu:default:1.0.0": {
+              "Order": 10010,
               "Name": "limits:default:1.0.0",
               "Spec": "default",
               "Project": "limits",
@@ -226,7 +242,7 @@
               "Locker": "azure-storage"
             },
             "slurm_pyxis_enroot:default:1.0.0": {
-              "Order": 10020,
+              "Order": 10010,
               "Name": "slurm_pyxis_enroot:default:1.0.0",
               "Spec": "default",
               "Project": "slurm_pyxis_enroot",
@@ -234,7 +250,7 @@
               "Locker": "azure-storage"
             },
             "nhc:default:1.0.0": {
-              "Order": 10030,
+              "Order": 10020,
               "Name": "nhc:default:1.0.0",
               "Spec": "default",
               "Project": "nhc",
@@ -304,33 +320,38 @@
         }
       ],
       "limits:default:1.0.0": [
-                      {
-                        "script": "set_limits.sh"
-                      }
+        {
+          "script": "set_limits.sh"
+        }
       ],
       "slurm_pyxis_enroot:default:1.0.0": [
-                      {
-                        "script": "install_pyxis.sh",
-                        "deps": [
-                                "common_functions.sh"
-                        ]
-                      },
-                      {
-                        "script": "configure_pyxis.sh",
-                        "deps": [
-                                "prolog.sh"
-                        ]
-                      },
-                      {
-                        "script": "install_enroot.sh"
-                      },
-                      {
-                        "script": "install_enroot_hooks.sh"
-                      },
-                      {
-                        "script": "slurmd_pmix.sh",
-                        "background": true
-                      }
+        {
+          "script": "install_pyxis.sh",
+          "deps": [
+            "common_functions.sh"
+          ]
+        },
+        {
+          "script": "configure_pyxis.sh",
+          "deps": [
+            "prolog.sh"
+          ]
+        },
+        {
+          "script": "install_enroot.sh"
+        },
+        {
+          "script": "install_enroot_hooks.sh"
+        },
+        {
+          "script": "slurmd_pmix.sh",
+          "background": true
+        }
+      ],
+      "misc_ubuntu:default:1.0.0": [
+        {
+          "script": "disable_unattended_upgrades.sh"
+        }
       ]
     }
   }

--- a/experimental/deploy_cycle_slurm_ndv4/config_pyxis_enroot_sacct.json
+++ b/experimental/deploy_cycle_slurm_ndv4/config_pyxis_enroot_sacct.json
@@ -217,9 +217,9 @@
             },
             "misc_ubuntu:default:1.0.0": {
               "Order": 10020,
-              "Name": "limits:default:1.0.0",
+              "Name": "misc_ubuntu:default:1.0.0",
               "Spec": "default",
-              "Project": "limits",
+              "Project": "misc_ubuntu",
               "Version": "1.0.0",
               "Locker": "azure-storage"
             }
@@ -235,9 +235,9 @@
             },
             "misc_ubuntu:default:1.0.0": {
               "Order": 10010,
-              "Name": "limits:default:1.0.0",
+              "Name": "misc_ubuntu:default:1.0.0",
               "Spec": "default",
-              "Project": "limits",
+              "Project": "misc_ubuntu",
               "Version": "1.0.0",
               "Locker": "azure-storage"
             }

--- a/experimental/deploy_cycle_slurm_ndv4/config_pyxis_enroot_sacct.json
+++ b/experimental/deploy_cycle_slurm_ndv4/config_pyxis_enroot_sacct.json
@@ -200,7 +200,7 @@
           "additional_slurm_config": "SuspendTime=-1",
           "SchedulerClusterInitSpecs": {
             "slurm_pyxis_enroot:default:1.0.0": {
-              "Order": 10020,
+              "Order": 10000,
               "Name": "slurm_pyxis_enroot:default:1.0.0",
               "Spec": "default",
               "Project": "slurm_pyxis_enroot",
@@ -208,10 +208,18 @@
               "Locker": "azure-storage"
             },
             "nhc:default:1.0.0": {
-              "Order": 10030,
+              "Order": 10010,
               "Name": "nhc:default:1.0.0",
               "Spec": "default",
               "Project": "nhc",
+              "Version": "1.0.0",
+              "Locker": "azure-storage"
+            },
+            "misc_ubuntu:default:1.0.0": {
+              "Order": 10020,
+              "Name": "limits:default:1.0.0",
+              "Spec": "default",
+              "Project": "limits",
               "Version": "1.0.0",
               "Locker": "azure-storage"
             }
@@ -219,6 +227,14 @@
           "LoginClusterInitSpecs": {
             "limits:default:1.0.0": {
               "Order": 10000,
+              "Name": "limits:default:1.0.0",
+              "Spec": "default",
+              "Project": "limits",
+              "Version": "1.0.0",
+              "Locker": "azure-storage"
+            },
+            "misc_ubuntu:default:1.0.0": {
+              "Order": 10010,
               "Name": "limits:default:1.0.0",
               "Spec": "default",
               "Project": "limits",
@@ -236,7 +252,7 @@
               "Locker": "azure-storage"
             },
             "slurm_pyxis_enroot:default:1.0.0": {
-              "Order": 10020,
+              "Order": 10010,
               "Name": "slurm_pyxis_enroot:default:1.0.0",
               "Spec": "default",
               "Project": "slurm_pyxis_enroot",
@@ -244,7 +260,7 @@
               "Locker": "azure-storage"
             },
             "nhc:default:1.0.0": {
-              "Order": 10030,
+              "Order": 10020,
               "Name": "nhc:default:1.0.0",
               "Spec": "default",
               "Project": "nhc",
@@ -316,33 +332,38 @@
         }
       ],
       "limits:default:1.0.0": [
-                      {
-                        "script": "set_limits.sh"
-                      }
+        {
+          "script": "set_limits.sh"
+        }
       ],
       "slurm_pyxis_enroot:default:1.0.0": [
-                      {
-                        "script": "install_pyxis.sh",
-                        "deps": [
-                                "common_functions.sh"
-                        ]
-                      },
-                      {
-                        "script": "configure_pyxis.sh",
-                        "deps": [
-                                "prolog.sh"
-                        ]
-                      },
-                      {
-                        "script": "install_enroot.sh"
-                      },
-                      {
-                        "script": "install_enroot_hooks.sh"
-                      },
-                      {
-                        "script": "slurmd_pmix.sh",
-                        "background": true
-                      }
+        {
+          "script": "install_pyxis.sh",
+          "deps": [
+            "common_functions.sh"
+          ]
+        },
+        {
+          "script": "configure_pyxis.sh",
+          "deps": [
+            "prolog.sh"
+          ]
+        },
+        {
+          "script": "install_enroot.sh"
+        },
+        {
+          "script": "install_enroot_hooks.sh"
+        },
+        {
+          "script": "slurmd_pmix.sh",
+          "background": true
+        }
+      ],
+      "misc_ubuntu:default:1.0.0": [
+        {
+          "script": "disable_unattended_upgrades.sh"
+        }
       ]
     }
   }

--- a/experimental/deploy_cycle_slurm_ndv4/scripts/disable_unattended_upgrades.sh
+++ b/experimental/deploy_cycle_slurm_ndv4/scripts/disable_unattended_upgrades.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sed -i '/distro_id/s/^\/*/\/\//' /etc/apt/apt.conf.d/50unattended-upgrades


### PR DESCRIPTION
Apply CC project to scheduler and login nodes to disable Ubuntu unattended upgrades.
This functionality is enabled only on base Ubuntu marketplace image. Ubuntu-DSVM already have it disabled.