### PR TITLE
Deploy_cycle_slurm_ndv4(Set sunrpc kernel parameter tcp_max_slot_table_entries=128)

### DIFF
--- a/experimental/deploy_cycle_slurm_ndv4/config_pyxis_enroot_sacct.json
+++ b/experimental/deploy_cycle_slurm_ndv4/config_pyxis_enroot_sacct.json
@@ -222,6 +222,14 @@
               "Project": "misc_ubuntu",
               "Version": "1.0.0",
               "Locker": "azure-storage"
+            },
+            "sunrpc_max_slots:default:1.0.0": {
+              "Order": 10030,
+              "Name": "sunrpc_max_slots:default:1.0.0",
+              "Spec": "default",
+              "Project": "sunrpc_max_slots",
+              "Version": "1.0.0",
+              "Locker": "azure-storage"
             }
           },
           "LoginClusterInitSpecs": {
@@ -238,6 +246,14 @@
               "Name": "misc_ubuntu:default:1.0.0",
               "Spec": "default",
               "Project": "misc_ubuntu",
+              "Version": "1.0.0",
+              "Locker": "azure-storage"
+            },
+            "sunrpc_max_slots:default:1.0.0": {
+              "Order": 10020,
+              "Name": "sunrpc_max_slots:default:1.0.0",
+              "Spec": "default",
+              "Project": "sunrpc_max_slots",
               "Version": "1.0.0",
               "Locker": "azure-storage"
             }
@@ -264,6 +280,14 @@
               "Name": "nhc:default:1.0.0",
               "Spec": "default",
               "Project": "nhc",
+              "Version": "1.0.0",
+              "Locker": "azure-storage"
+            },
+            "sunrpc_max_slots:default:1.0.0": {
+              "Order": 10030,
+              "Name": "sunrpc_max_slots:default:1.0.0",
+              "Spec": "default",
+              "Project": "sunrpc_max_slots",
               "Version": "1.0.0",
               "Locker": "azure-storage"
             }
@@ -363,6 +387,11 @@
       "misc_ubuntu:default:1.0.0": [
         {
           "script": "disable_unattended_upgrades.sh"
+        }
+      ],
+      "sunrpc_max_slots:default:1.0.0": [
+        {
+          "script": "sunrpc_tcp_max_slot_table_entries.sh"
         }
       ]
     }

--- a/experimental/deploy_cycle_slurm_ndv4/readme.md
+++ b/experimental/deploy_cycle_slurm_ndv4/readme.md
@@ -9,7 +9,7 @@ The NDv4 cluster will consist of
 - Automatic recovery from a reboot enabled (e.g NVMe SSD will be remounted and GPU clock freq reset)
 - Premium SSD's used for OS disks, with larger capacity (60GB)
 - Accelerated networking is enabled on NDv4
-- User home directories are mounted on Azure netapp files
+- User home directories are mounted on Azure netapp files (sunrpc kernel parameter tcp_max_slot_table_entries=128)
 - Extensive automatic pre-job healthchecks are enabled (Unhealthy nodes will be put into a DRAIN state)
 - A separate login node (separate from the scheduler is deployed)
 - Cyclecloud autoscaling is disabled.

--- a/experimental/deploy_cycle_slurm_ndv4/scripts/sunrpc_max_tcp_slot_table_entries.sh
+++ b/experimental/deploy_cycle_slurm_ndv4/scripts/sunrpc_max_tcp_slot_table_entries.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-TCP_MAX_SLOT_TABLE_ENTRIES=128
+MAX_TCP_SLOT_TABLE_ENTRIES=128
 SYSCTL_CONF=/etc/sysctl.conf
 ANF_MOUNT_POINTS="/apps /shared"
 
-echo "sunrpc.max_tcp_slot_table_entries=$TCP_MAX_SLOT_TABLE_ENTRIES" | sudo tee -a $SYSCTL_CONF > /dev/null
+echo "sunrpc.max_tcp_slot_table_entries=$MAX_TCP_SLOT_TABLE_ENTRIES" | sudo tee -a $SYSCTL_CONF > /dev/null
 sysctl -p
 
 for mount_point in $ANF_MOUNT_POINTS

--- a/experimental/deploy_cycle_slurm_ndv4/scripts/sunrpc_tcp_max_slot_table_entries.sh
+++ b/experimental/deploy_cycle_slurm_ndv4/scripts/sunrpc_tcp_max_slot_table_entries.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+TCP_MAX_SLOT_TABLE_ENTRIES=128
+MODPROBE_FILE=/etc/modprobe.d/sunrpc.conf
+
+echo "options sunrpc tcp_max_slot_table_entries=$TCP_MAX_SLOT_TABLE_ENTRIES" | sudo tee -a $MODPROBE_FILE > /dev/null

--- a/experimental/deploy_cycle_slurm_ndv4/scripts/sunrpc_tcp_max_slot_table_entries.sh
+++ b/experimental/deploy_cycle_slurm_ndv4/scripts/sunrpc_tcp_max_slot_table_entries.sh
@@ -4,7 +4,7 @@ TCP_MAX_SLOT_TABLE_ENTRIES=128
 SYSCTL_CONF=/etc/sysctl.conf
 ANF_MOUNT_POINTS="/apps /shared"
 
-echo "tcp_max_slot_table_entries=$TCP_MAX_SLOT_TABLE_ENTRIES" | sudo tee -a $SYSCTL_CONF > /dev/null
+echo "sunrpc.tcp_max_slot_table_entries=$TCP_MAX_SLOT_TABLE_ENTRIES" | sudo tee -a $SYSCTL_CONF > /dev/null
 sysctl -p
 
 for mount_point in $ANF_MOUNT_POINTS

--- a/experimental/deploy_cycle_slurm_ndv4/scripts/sunrpc_tcp_max_slot_table_entries.sh
+++ b/experimental/deploy_cycle_slurm_ndv4/scripts/sunrpc_tcp_max_slot_table_entries.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-MAX_TCP_SLOT_TABLE_ENTRIES=128
+TCP_MAX_SLOT_TABLE_ENTRIES=128
 SYSCTL_CONF=/etc/sysctl.conf
 ANF_MOUNT_POINTS="/apps /shared"
 
-echo "sunrpc.max_tcp_slot_table_entries=$MAX_TCP_SLOT_TABLE_ENTRIES" | sudo tee -a $SYSCTL_CONF > /dev/null
+echo "sunrpc.tcp_max_slot_table_entries=$TCP_MAX_SLOT_TABLE_ENTRIES" | sudo tee -a $SYSCTL_CONF > /dev/null
 sysctl -p
 
 for mount_point in $ANF_MOUNT_POINTS

--- a/experimental/deploy_cycle_slurm_ndv4/scripts/sunrpc_tcp_max_slot_table_entries.sh
+++ b/experimental/deploy_cycle_slurm_ndv4/scripts/sunrpc_tcp_max_slot_table_entries.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 
 TCP_MAX_SLOT_TABLE_ENTRIES=128
-MODPROBE_FILE=/etc/modprobe.d/sunrpc.conf
+SYSCTL_CONF=/etc/sysctl.conf
+ANF_MOUNT_POINTS="/apps /shared"
 
-echo "options sunrpc tcp_max_slot_table_entries=$TCP_MAX_SLOT_TABLE_ENTRIES" | sudo tee -a $MODPROBE_FILE > /dev/null
+echo "tcp_max_slot_table_entries=$TCP_MAX_SLOT_TABLE_ENTRIES" | sudo tee -a $SYSCTL_CONF > /dev/null
+sysctl -p
+
+for mount_point in $ANF_MOUNT_POINTS
+do
+   umount $mount_point
+   mount $mount_point
+done

--- a/experimental/deploy_cycle_slurm_ndv4/scripts/sunrpc_tcp_max_slot_table_entries.sh
+++ b/experimental/deploy_cycle_slurm_ndv4/scripts/sunrpc_tcp_max_slot_table_entries.sh
@@ -4,7 +4,7 @@ TCP_MAX_SLOT_TABLE_ENTRIES=128
 SYSCTL_CONF=/etc/sysctl.conf
 ANF_MOUNT_POINTS="/apps /shared"
 
-echo "sunrpc.tcp_max_slot_table_entries=$TCP_MAX_SLOT_TABLE_ENTRIES" | sudo tee -a $SYSCTL_CONF > /dev/null
+echo "sunrpc.max_tcp_slot_table_entries=$TCP_MAX_SLOT_TABLE_ENTRIES" | sudo tee -a $SYSCTL_CONF > /dev/null
 sysctl -p
 
 for mount_point in $ANF_MOUNT_POINTS


### PR DESCRIPTION
For ANF it is recommended to set the sunrpc kernel parameter tcp_max_slot_table_entries=128, to match a similar parameter on the ANF server. When a client overwhelms the server network stacks ability to process a workload, the server responds by decreasing the window size for the connection (throttling).

Sets the sunrpc kernel parameter tcp_max_slot_table_entries=128