### PR TITLE
Add ability to use variables in config dictionary keys

### DIFF
--- a/pyazhpc/azconfig.py
+++ b/pyazhpc/azconfig.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 import re
@@ -78,7 +79,8 @@ class ConfigFile:
             return input
 
     def preprocess(self, extended=True):
-        res = self.__evaluate(self.data, extended)
+        # copy of dict required
+        res = self.__evaluate(copy.deepcopy(self.data), extended)
         return res
 
     def read_keys(self, v):

--- a/pyazhpc/azconfig.py
+++ b/pyazhpc/azconfig.py
@@ -15,13 +15,16 @@ class ConfigFile:
         self.data = {}
         self.regex = re.compile(r'({{([^{}]*)}})')
 
-    def open(self, fname):
+    def open(self, fname, preprocess=True, preprocess_extended=False):
         log.debug("opening "+fname)
         self.file_location = os.path.dirname(fname)
         if self.file_location == "":
             self.file_location = "."
         with open(fname) as f:
             self.data = json.load(f)
+
+        if preprocess:
+            self.data = self.preprocess(extended=preprocess_extended)
 
     def save(self, fname):
         with open(fname, "w") as f:

--- a/pyazhpc/azhpc.py
+++ b/pyazhpc/azhpc.py
@@ -203,7 +203,7 @@ def do_connect(args):
         sshuser = adminuser
     else:
         sshuser = args.user
-    
+
     sshport = c.read_value("ssh_port", 22)
 
     jumpbox = c.read_value("install_from")
@@ -470,7 +470,7 @@ def _wait_for_deployment(resource_group, deploy_name):
                                         elif isinstance(value, list):
                                             wrapped_print(indent, str(key))
                                             pretty_print(value, indent+4)
-                                        else: 
+                                        else:
                                             wrapped_print(indent, f"{key}: {value}")
                                 else:
                                     wrapped_print(indent, str(d))
@@ -565,8 +565,8 @@ def do_slurm_resume(args):
     # first get the resource name
     resource_names, resource_list = _nodelist_expand(args.nodes)
 
-    # Create a copy of the configuration to use as template                                                                 
-    # for the final deployment configuration                                                                                
+    # Create a copy of the configuration to use as template
+    # for the final deployment configuration
     config = copy.deepcopy(config_orig)
     config["resources"] = {}
 
@@ -716,7 +716,7 @@ def do_run_install(args):
     if os.path.isdir(tmpdir):
         log.debug("removing existing tmp directory")
         shutil.rmtree(tmpdir)
-    
+
     adminuser = config["admin_user"]
     private_key_file = adminuser+"_id_rsa"
     public_key_file = adminuser+"_id_rsa.pub"
@@ -897,7 +897,7 @@ if __name__ == "__main__":
     preprocess_parser.set_defaults(func=do_preprocess)
 
     run_parser = subparsers.add_parser(
-        "run", 
+        "run",
         parents=[gopt_parser],
         add_help=False,
         description="run a command on the specified resources",
@@ -923,7 +923,7 @@ if __name__ == "__main__":
     )
 
     scp_parser = subparsers.add_parser(
-        "scp", 
+        "scp",
         parents=[gopt_parser],
         add_help=False,
         description="secure copy",

--- a/pyazhpc/azhpc.py
+++ b/pyazhpc/azhpc.py
@@ -1,4 +1,5 @@
 import argparse
+import copy
 import datetime
 import json
 import os
@@ -8,17 +9,16 @@ import socket
 import sys
 import textwrap
 import time
-import copy
+
+from cryptography.hazmat.backends import default_backend as crypto_default_backend
+from cryptography.hazmat.primitives import serialization as crypto_serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 import arm
 import azconfig
 import azinstall
 import azlog
 import azutil
-
-from cryptography.hazmat.primitives import serialization as crypto_serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.hazmat.backends import default_backend as crypto_default_backend
 
 log = azlog.getLogger(__name__)
 

--- a/pyazhpc/test/test_azconfig.py
+++ b/pyazhpc/test/test_azconfig.py
@@ -2,17 +2,15 @@ import unittest
 
 import azconfig
 
-
 class TestConfigFile(unittest.TestCase):
 
     def setUp(self):
         self.config = azconfig.ConfigFile()
         self.config.open("test/test_config_file.json")
-        self.config_preprocessed = self.config.preprocess()
 
     def test_read_simple_value(self):
         self.assertEqual(self.config.read_value("int_value"), 42)
-
+    
     def test_read_boolean_value(self):
         self.assertEqual(self.config.read_value("bool_value"), True)
 
@@ -22,25 +20,8 @@ class TestConfigFile(unittest.TestCase):
     def test_replace_double_curly_braces(self):
         self.assertEqual(self.config.read_value("double_curly_braces"), "simple_variable=42")
 
-    # Before preprocessing, config fields using variable name definitions are not expanded
-    def test_replace_in_dict_key_before_preprocessing(self):
-        self.assertEqual(
-            self.config.read_value("resources")["variables.resource_name"],
-            "bar"
-        )
-
-    def test_replace_in_dict_value_before_preprocessing(self):
-        self.assertEqual(
-            self.config.read_value("resources")["resource-name"],
-            "variables.resource_type"
-        )
-
-    # After preprocessing, config fields using variable name definitions are expanded
-    def test_replace_in_dict_key_after_preprocessing(self):
-        self.assertEqual(self.config_preprocessed["resources"]["foo"], "bar")
-
-    def test_replace_in_dict_value_after_preprocessing(self):
-        self.assertEqual(self.config_preprocessed["resources"]["resource-name"], "resource-type")
+    def test_replace_in_dict_key(self):
+        self.assertEqual(self.config.read_value("resources.foo"), "bar")
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyazhpc/test/test_azconfig.py
+++ b/pyazhpc/test/test_azconfig.py
@@ -20,5 +20,8 @@ class TestConfigFile(unittest.TestCase):
     def test_replace_double_curly_braces(self):
         self.assertEqual(self.config.read_value("double_curly_braces"), "simple_variable=42")
 
+    def test_replace_in_dict_key(self):
+        self.assertEqual(self.config.read_value("resources.foo"), "bar")
+
 if __name__ == "__main__":
     unittest.main()

--- a/pyazhpc/test/test_azconfig.py
+++ b/pyazhpc/test/test_azconfig.py
@@ -2,15 +2,17 @@ import unittest
 
 import azconfig
 
+
 class TestConfigFile(unittest.TestCase):
 
     def setUp(self):
         self.config = azconfig.ConfigFile()
         self.config.open("test/test_config_file.json")
+        self.config_preprocessed = self.config.preprocess()
 
     def test_read_simple_value(self):
         self.assertEqual(self.config.read_value("int_value"), 42)
-    
+
     def test_read_boolean_value(self):
         self.assertEqual(self.config.read_value("bool_value"), True)
 
@@ -20,8 +22,25 @@ class TestConfigFile(unittest.TestCase):
     def test_replace_double_curly_braces(self):
         self.assertEqual(self.config.read_value("double_curly_braces"), "simple_variable=42")
 
-    def test_replace_in_dict_key(self):
-        self.assertEqual(self.config.read_value("resources.foo"), "bar")
+    # Before preprocessing, config fields using variable name definitions are not expanded
+    def test_replace_in_dict_key_before_preprocessing(self):
+        self.assertEqual(
+            self.config.read_value("resources")["variables.resource_name"],
+            "bar"
+        )
+
+    def test_replace_in_dict_value_before_preprocessing(self):
+        self.assertEqual(
+            self.config.read_value("resources")["resource-name"],
+            "variables.resource_type"
+        )
+
+    # After preprocessing, config fields using variable name definitions are expanded
+    def test_replace_in_dict_key_after_preprocessing(self):
+        self.assertEqual(self.config_preprocessed["resources"]["foo"], "bar")
+
+    def test_replace_in_dict_value_after_preprocessing(self):
+        self.assertEqual(self.config_preprocessed["resources"]["resource-name"], "resource-type")
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyazhpc/test/test_config_file.json
+++ b/pyazhpc/test/test_config_file.json
@@ -5,11 +5,9 @@
     "double_curly_braces": "simple_variable={{variables.simple_variable}}",
     "variables": {
         "simple_variable": 42,
-        "resource_name": "foo",
-        "resource_type": "resource-type"
+        "resource_name": "foo"
     },
     "resources": {
-        "variables.resource_name": "bar",
-        "resource-name": "variables.resource_type"
+        "variables.resource_name": "bar"
     }
 }

--- a/pyazhpc/test/test_config_file.json
+++ b/pyazhpc/test/test_config_file.json
@@ -5,9 +5,11 @@
     "double_curly_braces": "simple_variable={{variables.simple_variable}}",
     "variables": {
         "simple_variable": 42,
-        "resource_name": "foo"
+        "resource_name": "foo",
+        "resource_type": "resource-type"
     },
     "resources": {
-        "variables.resource_name": "bar"
+        "variables.resource_name": "bar",
+        "resource-name": "variables.resource_type"
     }
 }

--- a/pyazhpc/test/test_config_file.json
+++ b/pyazhpc/test/test_config_file.json
@@ -4,6 +4,10 @@
     "use_variable": "variables.simple_variable",
     "double_curly_braces": "simple_variable={{variables.simple_variable}}",
     "variables": {
-        "simple_variable": 42
+        "simple_variable": 42,
+        "resource_name": "foo"
+    },
+    "resources": {
+        "variables.resource_name": "bar"
     }
 }


### PR DESCRIPTION
Adds the ability to use variables (e.g. "variables.<field>") in config dictionary key names which is useful in avoiding name collisions for resources created in the same account.

As an example, the json blob below is an example where a jumpbox VM is named using the expansion of the variable `variables.jumpbox_name` in the definition of resources.

```
{
    "location": "variables.location",
    "resource_group": "variables.resource_group",
    "install_from": "variables.jumpbox_name",
    "admin_user": "variables.admin_user",
    "variables": {
        "location": "<NOT-SET>",
        "resource_group": "<NOT-SET>",
        "vnet_resource_group": "variables.resource_group",
        "vnet_name": "<NOT-SET>",
        "admin_user": "hpcadmin",
        "image": "OpenLogic:CentOS:7.7:latest",
        "jb_vm_type": "Standard_D8s_v3",
        "jumpbox_name": "test-jumpbox"
    },
    "vnet": {
        "resource_group": "variables.vnet_resource_group",
        "name": "variables.vnet_name"
    },
    "resources": {
        "variables.jumpbox_name": {
            "type": "vm",
            "vm_type": "variables.jb_vm_type",
            "accelerated_networking": true,
            "public_ip": false,
            "image": "variables.image",
            "subnet": "default",
            "tags": [
                "jumpbox"
            ]
        }
    },
    "install": [
        {
            "script": "disable-selinux.sh",
            "tag": "variables.jumpbox_name",
            "sudo": true
        },
        {
            "script": "cndefault.sh",
            "tag": "variables.jumpbox_name",
            "sudo": true
        }
    ]
}
```

Commits also include removal of trailing whitespace in changed files.