### PR TITLE
Deploy_cycle_slurm_ndv4 (Corrected mariaDB config variable)

### DIFF
--- a/experimental/deploy_cycle_slurm_ndv4/prereqs_sacct_la_ws.json
+++ b/experimental/deploy_cycle_slurm_ndv4/prereqs_sacct_la_ws.json
@@ -31,7 +31,7 @@
       "args": [
         "variables.mariadb_resource_group",
         "variables.mariadb_name",
-        "variables.mariadb_admin",
+        "variables.mariadb_admin_user_name",
         "secret.{{variables.key_vault}}.{{variables.mariadb_password_secret_name}}"
       ]
     },


### PR DESCRIPTION
Correct azhpc config variable that defines the mariaDB admin name.