### PR TITLE
cc_slurm_nhc (Need to run check_app_gpu_clocks before check_cuda_bw 24.0 3)

### DIFF
--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96amsr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96amsr_v4.conf
@@ -141,8 +141,8 @@
  * || check_nvsmi_healthmon
  * || check_gpu_persistence
  * || check_nv_healthmon
- * || check_cuda_bw 24.0 3
  * || check_app_gpu_clocks
+ * || check_cuda_bw 24.0 3
  * || check_gpu_ecc 20000000 10000
  * || check_gpu_clock_throttling
  * || check_gpu_xid

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
@@ -138,8 +138,8 @@
  * || check_nvsmi_healthmon
  * || check_gpu_persistence
  * || check_nv_healthmon
- * || check_cuda_bw 24.0 3
  * || check_app_gpu_clocks
+ * || check_cuda_bw 24.0 3
  * || check_gpu_ecc 20000000 10000
  * || check_gpu_clock_throttling
  * || check_gpu_xid


### PR DESCRIPTION
Changed the order of the NHC tests on A100 GPUs.
-Need to run check_app_gpu_clocks before check_cuda_bw 24.0 3