### PR TITLE
cc_slurm_nhc (Add autoscaling support)

### DIFF
--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/epilog.sh
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/epilog.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-/sched/scripts/run_nhc.sh

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/prolog.sh
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/prolog.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-/sched/scripts/kill_nhc.sh

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/wait_for_nhc.sh
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/wait_for_nhc.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+pid=`ps -ef | grep -v kill_nhc | grep nhc | tr -s ' ' | cut -d ' ' -f2 | head -n 1`
+
+while ps -p $pid > /dev/null 2>&1
+do
+    sleep 10
+    TIMESTAMP=$(/bin/date '+%Y%m%d %H:%M:%S')
+    echo "${TIMESTAMP} [prolog] NHC processes still running" >> /var/log/nhc.log
+done
+
+TIMESTAMP=$(/bin/date '+%Y%m%d %H:%M:%S')
+echo "${TIMESTAMP} [prolog] NHC processes finished and job can start" >> /var/log/nhc.log
+exit 0

--- a/experimental/cc_slurm_nhc/readme.md
+++ b/experimental/cc_slurm_nhc/readme.md
@@ -65,9 +65,11 @@ You can add your own health checks to the NHC framework. An example is azure_cud
 You just add your custom health check to /etc/nhc/scripts and modify your nhc.conf file to use it (/etc/nhc/nhc.conf).
 
 ## Kill NHC via SLURM Prolog
-To prevent NHC from running while a job is running, we have provided a script to kill NHC processes (kill_nhc.sh). You can run this script before a job starts by using the SLURM PROLOG, set NHC_PROLOG=1 in the configure_nhc.sh script to enable this prolog (default) or set it to 0 to disable it..
+To prevent NHC from running while a job is running, we have provided a script to kill NHC processes (kill_nhc.sh). You can run this script before a job starts by using the SLURM PROLOG, set NHC_PROLOG=1 in the configure_nhc.sh script to enable this prolog (default) or set it to 0 to disable it.
 
->Note: If you run NHC via Epilog, then set HealthCheckInterval to a large value so it effectively only runs when a new node is provisioned in the cluster.
+>Note: If you have autoscaling enabled, then set AUTOSCALING=1 in the configure_nhc.sh script, this will replace kill_nhc.sh with wait_for_nhc.sh in the prolog.sh (To allow the NHC checks to complete (by waiting) when a node is autoscaled before starting your job)
+
+
 ## Run NHC via SLURM Epilog
 If you need to run NHC checks after a job completes (SLURM Epilog), then set NHC_EPILOG=1 in the configure_nhc.sh script.
 


### PR DESCRIPTION
Added support for autoscaling
-When a node is autoscaled, the prolog.sh waits for NHC to complete instead of killing NHC.
If prolog.sh or eliplog.sh do not exist they are created by configure_nhc.sh 
-remove prolog.sh and elilog.sh scripts.
