### PR TITLE
Add test repeats in NCCL allreduce and NCCL allreduce loopback

### DIFF
--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/azure_nccl_allreduce.nhc
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/azure_nccl_allreduce.nhc
@@ -1,5 +1,5 @@
 #!/bin/bash
-  
+
 # Check for NVlink ssues by running NCCL allreduce.
 # Expected performance is > 228 GB/s
 
@@ -21,34 +21,42 @@ function collect_nccl_allreduce_data() {
    IFS=$' \t\n'
 }
 
-
 function check_nccl_allreduce() {
 
    EXP_NCCL_ALLREDUCE_BW=$1
-   collect_nccl_allreduce_data
+   REPEATS="${2:-1}"
 
-   for ((i=0; i<${#nccl_allreduce_out_lines[*]}; i++))
+   for iter in $(seq 1 $REPEATS)
    do
-      if [[ "${nccl_allreduce_out_lines[$i]//FAILED}" != "${nccl_allreduce_out_lines[$i]}" ]]
+      collect_nccl_allreduce_data
+
+      for ((i=0; i<${#nccl_allreduce_out_lines[*]}; i++))
+      do
+         if [[ "${nccl_allreduce_out_lines[$i]//FAILED}" != "${nccl_allreduce_out_lines[$i]}" ]]
+         then
+            log "$nccl_allreduce_out"
+            die 1 "$FUNCNAME: NCCL allreduce, Out of bounds values failed"
+            return 1
+         fi
+         if [[ "${nccl_allreduce_out_lines[$i]//bandwidth}" != "${nccl_allreduce_out_lines[$i]}" ]]
+         then
+            IFS=$' \t\n'
+            nccl_allreduce_out_line=( ${nccl_allreduce_out_lines[$i]} )
+            avg_bus_bw=${nccl_allreduce_out_line[5]}
+            dbg "Measured Avg NCCL allreduce bus BW $avg_bus_bw GB/s (expected >=$EXP_NCCL_ALLREDUCE_BW GB/s)"
+            break
+         fi
+      done
+
+      if [[ $avg_bus_bw < $EXP_NCCL_ALLREDUCE_BW ]]
       then
-         log "$nccl_allreduce_out"
-         die 1 "$FUNCNAME: NCCL allreduce, Out of bounds values failed"
-         break
-      fi
-      if [[ "${nccl_allreduce_out_lines[$i]//bandwidth}" != "${nccl_allreduce_out_lines[$i]}" ]]
-      then
-         IFS=$' \t\n'
-         nccl_allreduce_out_line=( ${nccl_allreduce_out_lines[$i]} )
-         avg_bus_bw=${nccl_allreduce_out_line[5]}
-         dbg "Measured Avg NCCL allreduce bus BW $avg_bus_bw GB/s"
-         break
+         dbg "$nccl_allreduce_out"
+         log "Iteration ${iter} of ${REPEATS} failed: NCCL allreduce bandwidth $avg_bus_bw GB/s < $EXP_NCCL_ALLREDUCE_BW GB/s"
+      else
+         return 0
       fi
    done
-   dbg "Measured Avg NCCL allreduce bus BW=$avg_bus_bw, Expected NCCL allreduce BW=$EXP_NCCL_ALLREDUCE_BW"
-   if [[ $avg_bus_bw < $EXP_NCCL_ALLREDUCE_BW ]]
-   then
-      log "$nccl_allreduce_out"
-      die 1 "$FUNCNAME: NCCL allreduce, BUS BW (expected > $EXP_NCCL_ALLREDUCE_BW GB/s, but measured $avg_bus_bw GB/s"
-      return 1
-   fi
+
+   die 1 "$FUNCNAME: NCCL allreduce, BUS BW (expected >=$EXP_NCCL_ALLREDUCE_BW GB/s, but measured $avg_bus_bw GB/s)"
+   return 1
 }

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/azure_nccl_allreduce_ib_loopback.nhc
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/azure_nccl_allreduce_ib_loopback.nhc
@@ -1,5 +1,5 @@
 #!/bin/bash
-  
+
 # Check for IB issues by running NCCL allreduce disabling NCCL shared memory.
 # Expected performance is > 19 GB/s
 
@@ -21,28 +21,37 @@ function collect_nccl_allreduce_ib_loopback_data() {
    IFS=$' \t\n'
 }
 
-
 function check_nccl_allreduce_ib_loopback() {
 
    EXP_NCCL_ALLREDUCE_IB_LOOPBACK_BW=$1
-   collect_nccl_allreduce_ib_loopback_data
+   REPEATS="${2:-1}"
 
-   for ((i=0; i<${#nccl_allreduce_ib_loopback_out_lines[*]}; i++))
+
+   for iter in $(seq 1 $REPEATS)
    do
-      if [[ "${nccl_allreduce_ib_loopback_out_lines[$i]//bandwidth}" != "${nccl_allreduce_ib_loopback_out_lines[$i]}" ]]
+      collect_nccl_allreduce_ib_loopback_data
+
+      for ((i=0; i<${#nccl_allreduce_ib_loopback_out_lines[*]}; i++))
+      do
+         if [[ "${nccl_allreduce_ib_loopback_out_lines[$i]//bandwidth}" != "${nccl_allreduce_ib_loopback_out_lines[$i]}" ]]
+         then
+            IFS=$' \t\n'
+            nccl_allreduce_ib_loopback_out_line=( ${nccl_allreduce_ib_loopback_out_lines[$i]} )
+            avg_bus_bw=${nccl_allreduce_ib_loopback_out_line[5]}
+            dbg "Measured Avg NCCL allreduce ib loopback bus BW $avg_bus_bw GB/s (expected >=$EXP_NCCL_ALLREDUCE_IB_LOOPBACK_BW GB/s)"
+            break
+         fi
+      done
+
+      if [[ $avg_bus_bw < $EXP_NCCL_ALLREDUCE_IB_LOOPBACK_BW ]]
       then
-         IFS=$' \t\n'
-         nccl_allreduce_ib_loopback_out_line=( ${nccl_allreduce_ib_loopback_out_lines[$i]} )
-         avg_bus_bw=${nccl_allreduce_ib_loopback_out_line[5]}
-         dbg "Measured Avg NCCL allreduce ib loopback bus BW $avg_bus_bw GB/s"
-         break
+         dbg "$nccl_allreduce_ib_loopback_out"
+         log "Iteration ${iter} of ${REPEATS} failed: NCCL allreduce IB loopback bandwidth $avg_bus_bw GB/s < $EXP_NCCL_ALLREDUCE_IB_LOOPBACK_BW GB/s"
+      else
+         return 0
       fi
-   done
-   dbg "Measured Avg NCCL allreduce IB loopback bus BW=$avg_bus_bw, Expected NCCL allreduce IB loopback BW=$EXP_NCCL_ALLREDUCE_IB_LOOPBACK_BW"
-   if [[ $avg_bus_bw < $EXP_NCCL_ALLREDUCE_IB_LOOPBACK_BW ]]
-   then
-      log "$nccl_allreduce_ib_loopback_out"
-      die 1 "$FUNCNAME: NCCL allreduce IB loopback, BUS BW (expected > $EXP_NCCL_ALLREDUCE_IB_LOOPBACK_BW GB/s, but measured $avg_bus_bw GB/s"
-      return 1
-   fi
+  done
+
+  die 1 "$FUNCNAME: NCCL allreduce, BUS BW (expected >=$EXP_NCCL_ALLREDUCE_BW GB/s, but measured $avg_bus_bw GB/s)"
+  return 1
 }

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96amsr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96amsr_v4.conf
@@ -142,11 +142,11 @@
  * || check_gpu_persistence
  * || check_nv_healthmon
  * || check_app_gpu_clocks
- * || check_cuda_bw 24.0 3
+ * || check_cuda_bw 24.0 10
  * || check_gpu_ecc 20000000 10000
  * || check_gpu_clock_throttling
  * || check_gpu_xid
- * || check_nccl_allreduce 228.0
+ * || check_nccl_allreduce 228.0 10
 
 
 ########################################################################
@@ -154,5 +154,5 @@
 ##### Additional IB checks
 #####
 * || check_ib_bw_gdr 185.0
-* || check_nccl_allreduce_ib_loopback 18.0
+* || check_nccl_allreduce_ib_loopback 18.0 10
 * || check_ib_link_flapping 6

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
@@ -139,11 +139,11 @@
  * || check_gpu_persistence
  * || check_nv_healthmon
  * || check_app_gpu_clocks
- * || check_cuda_bw 24.0 3
+ * || check_cuda_bw 24.0 10
  * || check_gpu_ecc 20000000 10000
  * || check_gpu_clock_throttling
  * || check_gpu_xid
- * || check_nccl_allreduce 228.0
+ * || check_nccl_allreduce 228.0 10
 
 
 #######################################################################
@@ -151,5 +151,5 @@
 #### Additional IB checks
 ####
  * || check_ib_bw_gdr 185.0
- * || check_nccl_allreduce_ib_loopback 18.0
+ * || check_nccl_allreduce_ib_loopback 18.0 10
  * || check_ib_link_flapping 6


### PR DESCRIPTION
On healthy nodes we observed some variability over time that may cause false test failures. Mitigating issue by repeating the test multiple times.
The test will exit successfully at the first occurrence of bandwidth above the designated threshold.
If the test is negative, it will be repeated up to the maximum amount of times indicated (default 1). The test will fail if all the tests report bandwidths below designated threshold.