### PR TITLE
Added netstat check

### DIFF
--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/azure_ib_write_bw_gdr.nhc
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/azure_ib_write_bw_gdr.nhc
@@ -23,6 +23,10 @@ do
    IB_WRITE_BW_OUT1_RC=$?
    if [[ $IB_WRITE_BW_OUT1_RC != 0 ]]; then
       log "$IB_WRITE_BW_OUT1"
+      PORT=$(echo $IB_WRITE_BW_OUT1 | grep -oP '(?<=port\s)\w+')
+      NETSTAT_OUT=$(netstat -lnp | grep $PORT)
+      log "Running: netstat -lnp | grep $PORT:"
+      log "$NETSTAT_OUT"
       die 1 "$FUNCNAME: $IB_WRITE_BW returned error code $IB_WRITE_BW_OUT1_RC"
       return 1
    fi
@@ -32,6 +36,10 @@ do
    IB_WRITE_BW_OUT2_RC=$?
    if [[ $IB_WRITE_BW_OUT2_RC != 0 ]]; then
       log "$IB_WRITE_BW_OUT2"
+      PORT=$(echo $IB_WRITE_BW_OUT2 | grep -oP '(?<=port\s)\w+')
+      NETSTAT_OUT=$(netstat -lnp | grep $PORT)
+      log "Running: netstat -lnp | grep $PORT:"
+      log "$NETSTAT_OUT"
       die 1 "$FUNCNAME: $IB_WRITE_BW returned error code $IB_WRITE_BW_OUT2_RC"
       return 1
    fi


### PR DESCRIPTION
At times `check_ib_bw_gdr` fails with the following error:

```
Couldn't listen to port 18515
Unable to open file descriptor for socket connection Unable to init the socket connection
Couldn't connect to slurmcluster-hpc-pg0-277:18515
Unable to open file descriptor for socket connection Unable to init the socket connection
```

Adding `netstat` command to provide additional insights on port status.