### PR TITLE
Modified NDv4/NDmv4 configuration for UbuntuHPC 20.04

### DIFF
--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/build_perftest_gdr.sh
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/build_perftest_gdr.sh
@@ -7,7 +7,7 @@ INSTALL_DIR=/opt
 source $CYCLECLOUD_SPEC_PATH/files/common_functions.sh
 
 if ! is_slurm_controller; then
-   apt-get install -y pciutils-dev
+   apt-get install -y libpci-dev
    cd ${INSTALL_DIR}
    wget https://github.com/linux-rdma/perftest/releases/download/v${VERSION}/perftest-${VERSION}.${VERSION_HASH}.tar.gz
    tar xvf perftest-${VERSION}.${VERSION_HASH}.tar.gz

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96amsr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96amsr_v4.conf
@@ -49,7 +49,7 @@
 ###
  * || check_fs_mount_rw -t "sysfs" -s "sysfs" -f "/sys"
  * || check_fs_mount_rw -t "proc" -s "proc" -f "/proc"
- * || check_fs_mount_rw -t "devtmpfs" -s "udev" -f "/dev"
+ * || check_fs_mount_rw -t "devtmpfs" -s "devtmpfs" -f "/dev"
  * || check_fs_mount_rw -t "devpts" -s "devpts" -f "/dev/pts"
  * || check_fs_mount_rw -t "tmpfs" -s "tmpfs" -f "/run"
  * || check_fs_mount_rw -t "ext4" -s "/dev/sda1" -f "/"

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96amsr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96amsr_v4.conf
@@ -66,7 +66,7 @@
  * || check_fs_mount_rw -t "fusectl" -s "fusectl" -f "/sys/fs/fuse/connections"
  * || check_fs_mount_rw -t "configfs" -s "configfs" -f "/sys/kernel/config"
  * || check_fs_mount_rw -t "ext4" -s "/dev/sdb1" -f "/mnt"
- * || check_fs_mount_rw -t "fuse.lxcfs" -s "lxcfs" -f "/var/lib/lxcfs"
+# * || check_fs_mount_rw -t "fuse.lxcfs" -s "lxcfs" -f "/var/lib/lxcfs"
  * || check_fs_mount_rw -t "tracefs" -s "tracefs" -f "/sys/kernel/debug/tracing"
  * || check_fs_mount_rw -t "nfs4" -s "*:/sched" -f "/sched"
  * || check_fs_mount_rw -t "nfs" -s "*:/*" -f "/shared"

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96amsr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96amsr_v4.conf
@@ -123,7 +123,7 @@
 ### Process checks
 ###
  * || check_ps_loadavg 192
- * || check_ps_service -S -u root sshd
+ * || check_ps_service -S -u root -m 'sshd:' sshd
  * || check_ps_service -r -d rpc.statd nfslock
 
 

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96amsr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96amsr_v4.conf
@@ -52,7 +52,7 @@
  * || check_fs_mount_rw -t "devtmpfs" -s "devtmpfs" -f "/dev"
  * || check_fs_mount_rw -t "devpts" -s "devpts" -f "/dev/pts"
  * || check_fs_mount_rw -t "tmpfs" -s "tmpfs" -f "/run"
- * || check_fs_mount_rw -t "ext4" -s "/dev/sda1" -f "/"
+ * || check_fs_mount_rw -t "ext4" -s "/dev/root" -f "/"
  * || check_fs_mount_rw -t "securityfs" -s "securityfs" -f "/sys/kernel/security"
  * || check_fs_mount_rw -t "tmpfs" -s "tmpfs" -f "/dev/shm"
  * || check_fs_mount_rw -t "tmpfs" -s "tmpfs" -f "/run/lock"

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
@@ -49,7 +49,7 @@
 ###
  * || check_fs_mount_rw -t "sysfs" -s "sysfs" -f "/sys"
  * || check_fs_mount_rw -t "proc" -s "proc" -f "/proc"
- * || check_fs_mount_rw -t "devtmpfs" -s "udev" -f "/dev"
+ * || check_fs_mount_rw -t "devtmpfs" -s "devtmpfs" -f "/dev"
  * || check_fs_mount_rw -t "devpts" -s "devpts" -f "/dev/pts"
  * || check_fs_mount_rw -t "tmpfs" -s "tmpfs" -f "/run"
  * || check_fs_mount_rw -t "ext4" -s "/dev/sda1" -f "/"

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
@@ -66,7 +66,7 @@
  * || check_fs_mount_rw -t "fusectl" -s "fusectl" -f "/sys/fs/fuse/connections"
  * || check_fs_mount_rw -t "configfs" -s "configfs" -f "/sys/kernel/config"
  * || check_fs_mount_rw -t "ext4" -s "/dev/sdb1" -f "/mnt"
- * || check_fs_mount_rw -t "fuse.lxcfs" -s "lxcfs" -f "/var/lib/lxcfs"
+# * || check_fs_mount_rw -t "fuse.lxcfs" -s "lxcfs" -f "/var/lib/lxcfs"
  * || check_fs_mount_rw -t "tracefs" -s "tracefs" -f "/sys/kernel/debug/tracing"
  * || check_fs_mount_rw -t "nfs4" -s "*:/*" -f "/sched"
  * || check_fs_mount_rw -t "nfs" -s "*:/*" -f "/shared"

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
@@ -52,7 +52,7 @@
  * || check_fs_mount_rw -t "devtmpfs" -s "devtmpfs" -f "/dev"
  * || check_fs_mount_rw -t "devpts" -s "devpts" -f "/dev/pts"
  * || check_fs_mount_rw -t "tmpfs" -s "tmpfs" -f "/run"
- * || check_fs_mount_rw -t "ext4" -s "/dev/sda1" -f "/"
+ * || check_fs_mount_rw -t "ext4" -s "/dev/root" -f "/"
  * || check_fs_mount_rw -t "securityfs" -s "securityfs" -f "/sys/kernel/security"
  * || check_fs_mount_rw -t "tmpfs" -s "tmpfs" -f "/dev/shm"
  * || check_fs_mount_rw -t "tmpfs" -s "tmpfs" -f "/run/lock"

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
@@ -120,7 +120,7 @@
 ### Process checks
 ###
  * || check_ps_loadavg 192
- * || check_ps_service -S -u root sshd
+ * || check_ps_service -S -u root -m 'sshd:' sshd
  * || check_ps_service -r -d rpc.statd nfslock
 
 


### PR DESCRIPTION
Under Ubuntu-DSVM 20.04 some checks need to be modified in order to correctly pass the tests.
Also the `pciutils-dev` package required by perftest has been renamed to `libpci-dev`.