### PR TITLE
Cc slurm nhc

### DIFF
--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/configure_nhc.sh
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/configure_nhc.sh
@@ -87,6 +87,9 @@ function update_slurm_prolog_epilog() {
    script=$2
    grep -qi /sched/scripts/${prolog_epilog}.sh $SLURM_CONF
    prolog_epilog_does_not_exist=$?
+   if ! [ -d /sched/scripts ]; then
+        mkdir /sched/scripts
+   fi
    cp $CYCLECLOUD_SPEC_PATH/files/$script /sched/scripts
    chmod +x /sched/scripts/$script
    if [[ $prolog_epilog_does_not_exist == 1 ]]; then

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96amsr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96amsr_v4.conf
@@ -69,7 +69,7 @@
 # * || check_fs_mount_rw -t "fuse.lxcfs" -s "lxcfs" -f "/var/lib/lxcfs"
  * || check_fs_mount_rw -t "tracefs" -s "tracefs" -f "/sys/kernel/debug/tracing"
  * || check_fs_mount_rw -t "nfs4" -s "*:/sched" -f "/sched"
- * || check_fs_mount_rw -t "nfs" -s "*:/*" -f "/shared"
+ * || check_fs_mount_rw -t "nfs*" -s "*:/*" -f "/shared"
  * || check_fs_mount_rw -t "xfs" -s "/dev/*" -f "/mnt/resource_nvme"
  * || check_fs_used /dev 90%
  * || check_fs_used / 90%

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
@@ -69,7 +69,7 @@
 # * || check_fs_mount_rw -t "fuse.lxcfs" -s "lxcfs" -f "/var/lib/lxcfs"
  * || check_fs_mount_rw -t "tracefs" -s "tracefs" -f "/sys/kernel/debug/tracing"
  * || check_fs_mount_rw -t "nfs4" -s "*:/*" -f "/sched"
- * || check_fs_mount_rw -t "nfs" -s "*:/*" -f "/shared"
+ * || check_fs_mount_rw -t "nfs*" -s "*:/*" -f "/shared"
  * || check_fs_mount_rw -t "xfs" -s "/dev/*" -f "/mnt/resource_nvme"
  * || check_fs_used /dev 90%
  * || check_fs_used / 90%


### PR DESCRIPTION
- Create /sched/scripts dir if it does not exist.
- Modified /shared mount check, changed nfs protocol matching pattern to 'nfs*' (will allow nfs3 and nfs4). If default /shared is deployed it uses nfs4 be default.