### PR TITLE
cc_slurm_nhc (Added check for exclusive node in run_nhc.sh epilog)

### DIFF
--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/run_nhc.sh
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/run_nhc.sh
@@ -5,9 +5,34 @@ function set_detached_mode() {
    sudo sed -i "s/DETACHED_MODE.*/DETACHED_MODE=${TARGET_MODE}/g" /etc/default/nhc
 }
 
+function exclusive_node() {
+BASE_DIR="/sys/fs/cgroup/memory/slurm"
+cntu=0
+for dir in ${BASE_DIR}/uid_*
+do
+    cntu=$((cntu+1))
+    if [[ $cntu -gt 1 ]]; then
+       return 1
+    fi
+    cntj=0
+    for job in ${dir}/job_*
+    do
+        cntj=$((cntj+1))
+        if [[ $cntj -gt 1 ]]; then
+           return 1
+        fi
+    done
+done
+}
+
+exclusive_node
+exclusive_node_rc=$?
+
 set_detached_mode 0
-sudo /usr/sbin/nhc
-NHC_RC=$?
+if [ $exclusive_node_rc -eq 0 ]; then
+   sudo /usr/sbin/nhc
+   NHC_RC=$?
+fi
 set_detached_mode 1
 
 exit ${NHC_RC}


### PR DESCRIPTION
- Added check in run_nhc.sh epilog script to check if you are on a slurm exclusive node, if on exclusive node run post job nhc, otherwise do not run it.