### PR TITLE
cc_slurm_nhc (Corrected pid extraction in wait_for_nhc.sh)

### DIFF
--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/run_nhc.sh
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/run_nhc.sh
@@ -10,18 +10,22 @@ BASE_DIR="/sys/fs/cgroup/memory/slurm"
 cntu=0
 for dir in ${BASE_DIR}/uid_*
 do
-    cntu=$((cntu+1))
-    if [[ $cntu -gt 1 ]]; then
-       return 1
+    if [ -d $dir ]; then
+       cntu=$((cntu+1))
+       if [[ $cntu -gt 1 ]]; then
+          return 1
+       fi
+       cntj=0
+       for job in ${dir}/job_*
+       do
+           if [ -d $job ]; then
+              cntj=$((cntj+1))
+              if [[ $cntj -gt 0 ]]; then
+                 return 1
+              fi
+           fi
+       done
     fi
-    cntj=0
-    for job in ${dir}/job_*
-    do
-        cntj=$((cntj+1))
-        if [[ $cntj -gt 1 ]]; then
-           return 1
-        fi
-    done
 done
 }
 
@@ -29,7 +33,9 @@ exclusive_node
 exclusive_node_rc=$?
 
 set_detached_mode 0
+NHC_RC=0
 if [ $exclusive_node_rc -eq 0 ]; then
+   echo "[Epilog] execute nhc" >> /var/log/nhc.log
    sudo /usr/sbin/nhc
    NHC_RC=$?
 fi

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/wait_for_nhc.sh
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/wait_for_nhc.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+while [ ! -f /usr/sbin/nhc ];do
+sleep 2
+echo "[Prolog] waiting for /usr/sbin/nhc" >> /var/log/nhc.log
+done
+
 pid=`ps -ef | grep -v grep | grep /usr/sbin/nhc | tr -s ' ' | cut -d ' ' -f2 | head -n 1`
 
 while ps -p $pid > /dev/null 2>&1

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/wait_for_nhc.sh
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/wait_for_nhc.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-pid=`ps -ef | grep -v kill_nhc | grep nhc | tr -s ' ' | cut -d ' ' -f2 | head -n 1`
+pid=`ps -ef | grep -v grep | grep /usr/sbin/nhc | tr -s ' ' | cut -d ' ' -f2 | head -n 1`
 
 while ps -p $pid > /dev/null 2>&1
 do


### PR DESCRIPTION
-Corrected error in pid extraction (while loop was going into an infinite loop, giving a prolog error)
-Corrected error in run_nhc.sh (function exclusive_node)