### PR TITLE
Fix Cc slurm nhc autoscaling bug

### DIFF
--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/wait_for_nhc.sh
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/wait_for_nhc.sh
@@ -16,4 +16,9 @@ done
 
 TIMESTAMP=$(/bin/date '+%Y%m%d %H:%M:%S')
 echo "${TIMESTAMP} [prolog] NHC processes finished and job can start" >> /var/log/nhc.log
-exit 0
+
+if [ -f /var/run/nhc/nhc.status ]; then
+   exit 1
+else
+   exit 0
+fi

--- a/experimental/cc_slurm_nhc/readme.md
+++ b/experimental/cc_slurm_nhc/readme.md
@@ -67,11 +67,11 @@ You just add your custom health check to /etc/nhc/scripts and modify your nhc.co
 ## Kill NHC via SLURM Prolog
 To prevent NHC from running while a job is running, we have provided a script to kill NHC processes (kill_nhc.sh). You can run this script before a job starts by using the SLURM PROLOG, set NHC_PROLOG=1 in the configure_nhc.sh script to enable this prolog (default) or set it to 0 to disable it.
 
->Note: If you have autoscaling enabled, then set AUTOSCALING=1 in the configure_nhc.sh script, this will replace kill_nhc.sh with wait_for_nhc.sh in the prolog.sh (To allow the NHC checks to complete (by waiting) when a node is autoscaled before starting your job)
+>Note: If you have autoscaling enabled, then set AUTOSCALING=1 in the configure_nhc.sh script, this will replace kill_nhc.sh with wait_for_nhc.sh in the prolog.sh (To allow the NHC checks to complete (by waiting) when a node is autoscaled before starting your job. There is an additional prolog option when AUTOSCALING=1. If PROLOG_NOHOLD_REQUEUE=1 and NHC fails, the slurm job will be requeued with no hold (i.e It will attempt to allocate new nodes for the job), the default behavior is to requeue with a hold.)
 
 
 ## Run NHC via SLURM Epilog
-If you need to run NHC checks after a job completes (SLURM Epilog), then set NHC_EPILOG=1 in the configure_nhc.sh script.
+If you need to run NHC checks after a job completes (SLURM Epilog), then set NHC_EPILOG=1 in the configure_nhc.sh script. The NHC will only run via EPILOG (after job) only if its an exclusive job (i.e no other jobs are running on the node).
 
 >Note: If you run NHC via Epilog, then set HealthCheckInterval to a large value so it effectively only runs when a new node is provisioned in the cluster.
 


### PR DESCRIPTION
Fixed bug when NHC is used with autoscaling enabled (i.e AUTOSCALING=1). Added an exit code in the PROLOG, if NHC passed (exit code = 0), if NHC failed (exit code =1).

Added an additional PROLOG option (when AUTOSCALING=1 only). 
if
 PROLOG_NOHOLD_REQUEUE=1
and NHC fails (prolog exit code =1), the job will be requeued with no HOLD, i.e. Will attempt to allocate new VM's for the job.
(Default is job will be requeued (with a hold), node will be deallocated (PROLOG_NOHOLD_REQUEUE=0)