### PR TITLE
Add Xid code check for RPC from GSP timeout error

### DIFF
--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/azure_gpu_xid.nhc
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/azure_gpu_xid.nhc
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Check for the following GPU Xid errors in dmesg
-XID_EC="48 56 57 58 62 63 64 65 68 69 73 74 79 80 81 92"
+XID_EC="48 56 57 58 62 63 64 65 68 69 73 74 79 80 81 92 119 120"
 GPU_XID_TEST="GPU Xid errors detected"
 
 

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/azure_gpu_xid.nhc
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/azure_gpu_xid.nhc
@@ -17,7 +17,6 @@ if [ $RC == 0 ]; then
           die 1 "$FUNCNAME: $GPU_XID_TEST: $xid_found_line"
        else
           dbg "No GPU Xid $XID error found in dmesg"
-          return 0
        fi
    done
 else

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96amsr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96amsr_v4.conf
@@ -138,6 +138,7 @@
 #####
 ##### GPU checks
 #####
+ * || check_gpu_xid
  * || check_nvsmi_healthmon
  * || check_gpu_persistence
  * || check_nv_healthmon
@@ -145,7 +146,6 @@
  * || check_cuda_bw 24.0 10
  * || check_gpu_ecc 20000000 10000
  * || check_gpu_clock_throttling
- * || check_gpu_xid
  * || check_nccl_allreduce 228.0 10
 
 

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/nd96asr_v4.conf
@@ -135,6 +135,7 @@
 ####
 #### GPU checks
 ####
+ * || check_gpu_xid
  * || check_nvsmi_healthmon
  * || check_gpu_persistence
  * || check_nv_healthmon
@@ -142,7 +143,6 @@
  * || check_cuda_bw 24.0 10
  * || check_gpu_ecc 20000000 10000
  * || check_gpu_clock_throttling
- * || check_gpu_xid
  * || check_nccl_allreduce 228.0 10
 
 


### PR DESCRIPTION
Nvidia driver 510 enables the GPU System Processor (GSP) by default. The GSP allows to offload GPU initialization and management tasks from the CPU improving performance due to lower latency access to GPU hardware internals.
Such driver includes a bug that causes RPCs to GSP to timeout, preventing the correct GPU initialization. This in turn causes NHC GPU tests to hang indefinitely and the node to be drained because of NHC timeout.

To allow a better identification of this error the Xid codes 119 and 120 are added to the `azure_gpu_xid` test.
Also, the test has been moved at the top of the set of GPU tests to identify GPU health issues before any other test requiring GPU initialization are ran.

Finally, a bug in the `azure_gpu_xid` test has been squelched by removing a return statement that was stopping the Xid errors check at the first passing iteration.