### PR TITLE
App pinning tool (Support using tool directly in mpi run script)

### DIFF
--- a/experimental/check_app_pinning_tool/check_app_pinning.py
+++ b/experimental/check_app_pinning_tool/check_app_pinning.py
@@ -751,7 +751,9 @@ def report(app_pattern, print_pinning_syntax, topo_d, process_d, sku_name, l3cac
           print("{:<12} {:<17} {:<17} {:<15} {:<17} {:<15} {:<15}".format(pid,threads,running_threads,last_core_id,cpus_allowed,numas,gpu_id))
     elif print_pinning_syntax:
        total_number_processes = total_number_vms * number_processes_per_vm
-       os.environ["AZ_MPI_NP"] = total_number_processes
+       f = open("AZ_MPI_NP", "w")
+       f.write(str(total_number_processes))
+       f.close
        print("Process/thread {} MPI mapping/pinning syntax for total {} processes ( {} processes per VM and {} threads per process)".format(mpi_type, total_number_processes, number_processes_per_vm, number_threads_per_process))
        print("")
        if sku_name == "Standard_HB120rs_v3" and number_threads_per_process > 1:
@@ -763,47 +765,34 @@ def report(app_pattern, print_pinning_syntax, topo_d, process_d, sku_name, l3cac
        if have_warning and not force:
           print("NOTE: MPI process/thread pinning syntax will NOT be displayed until the warnings above have been corrected")
        else:
+          f = open("AZ_MPI_ARGS", "w")
           if mpi_type == "openmpi":
              if number_threads_per_process == 1 and number_processes_per_vm == number_cores_per_vm:
-                az_mpi_args = "--bind-to cpulist:ordered --cpu-list {}".format(list_to_str(pinning_syntax_l))
+                az_mpi_args = "--bind-to cpulist:ordered --cpu-list {} -report-bindings".format(list_to_str(pinning_syntax_l))
                 print("mpirun -np {} {}".format(total_number_processes, az_mpi_args))
-#                print("-np {} --bind-to cpulist:ordered --cpu-list {}".format(total_number_processes, list_to_str(pinning_syntax_l)))
              else:
-                az_mpi_args = "--bind-to l3cache --map-by ppr:{}:numa".format(number_processes_per_numa)
+                az_mpi_args = "--bind-to l3cache --map-by ppr:{}:numa -report-bindings".format(number_processes_per_numa)
                 print("mpirun -np {} {}".format(total_number_processes, az_mpi_args))
-#                print("-np {} --bind-to l3cache --map-by ppr:{}:numa".format(total_number_processes, number_processes_per_numa))
-             os.environ["AZ_MPI_ARGS"] = az_mpi_args
           elif mpi_type == "intel":
              num_l3cache = len(l3cache_topo_d["l3cache_ids"])
              if number_threads_per_process == 1:
-                az_mpi_args = "-genv I_MPI_PIN_PROCESSOR {}".format(list_to_str(pinning_syntax_l))
-                print("mpirun -n {} {}".format(total_number_processes, az_mpi_args))
-#                print("-genv I_MPI_PIN_PROCESSOR=",list_to_str(pinning_syntax_l))
+                az_mpi_args = "-genv I_MPI_PIN_PROCESSOR {} -genv FI_PROVIDER mlx -genv I_MPI_COLL_EXTERNAL 1 -genv I_MPI_DEBUG 6".format(list_to_str(pinning_syntax_l))
+                print("mpirun -np {} {}".format(total_number_processes, az_mpi_args))
              elif number_processes_per_vm < num_l3cache:
-                az_mpi_args = "-genv I_MPI_PIN_DOMAIN {}".format("auto:compact")
-                print("mpirun -n {} {}".format(total_number_processes, az_mpi_args))
-#                print("export I_MPI_PIN_DOMAIN=auto:compact")
+                az_mpi_args = "-genv I_MPI_PIN_DOMAIN {} -genv FI_PROVIDER mlx -genv I_MPI_COLL_EXTERNAL 1 -genv I_MPI_DEBUG 6".format("auto:compact")
+                print("mpirun -np {} {}".format(total_number_processes, az_mpi_args))
              else:
-                az_mpi_args = "-genv I_MPI_PIN_DOMAIN {}:compact".format(number_cores_in_l3cache)
-                print("mpirun -n {} {}".format(total_number_processes, az_mpi_args))
-#                print("export I_MPI_PIN_DOMAIN={}:compact".format(number_cores_in_l3cache))
-             os.environ["AZ_MPI_ARGS"] = az_mpi_args
+                az_mpi_args = "-genv I_MPI_PIN_DOMAIN {}:compact -genv FI_PROVIDER mlx -genv I_MPI_COLL_EXTERNAL 1 -genv I_MPI_DEBUG 6".format(number_cores_in_l3cache)
+                print("mpirun -np {} {}".format(total_number_processes, az_mpi_args))
           else:
              if number_threads_per_process == 1:
                 az_mpi_args = "-genv MV2_SHOW_CPU_BINDING=1 -genv MV2_CPU_BINDING_POLICY=scatter -genv MV2_CPU_BINDING_LEVEL=core"
                 print("mpirun -np {} {}".format(total_number_processes, az_mpi_args))
-#                print("export MV2_SHOW_CPU_BINDING=1")
-#                print("export MV2_CPU_BINDING_POLICY=scatter")
-#                print("export MV2_CPU_BINDING_LEVEL=core")
              else:
-                az_mpi_args = "-genv MV2_SHOW_CPU_BINDING=1 -genv MV2_THREADS_PER_PROCESS={} -genv MV2_CPU_BINDING_POLICY=hybrid MV2_HYBRID_BINDING_POLICY=linear".format(number_cores_in_l3cache)
+                az_mpi_args = "-genv MV2_SHOW_CPU_BINDING=1 -genv MV2_THREADS_PER_PROCESS={} -genv MV2_CPU_BINDING_POLICY=hybrid -genv MV2_HYBRID_BINDING_POLICY=linear".format(number_cores_in_l3cache)
                 print("mpirun -np {} {}".format(total_number_processes, az_mpi_args))
-#                print("export MV2_SHOW_CPU_BINDING=1")
-#                print("export MV2_THREADS_PER_PROCESS={}".format(number_cores_in_l3cache))
-#                print("export MV2_CPU_BINDING_POLICY=hybrid")
-#                print("export MV2_HYBRID_BINDING_POLICY=linear")
-             os.environ["AZ_MPI_ARGS"] = az_mpi_args
-
+          f.write(az_mpi_args)
+          f.close
 
 def main():
    total_number_vms = 0

--- a/experimental/check_app_pinning_tool/readme.md
+++ b/experimental/check_app_pinning_tool/readme.md
@@ -223,10 +223,13 @@ Warning: threads corresponding to process 11588 are mapped to multiple L3cache(s
 [azureuser@cghb120v3 ~]$
 ```
 
+
 You can also use this pinning tool directly in an MPI script to pass and use the optimal pinning parameters to mpirun.
 The following files will be created in your current working directory.
+```
 AZ_MPI_NP  : File containing the total number of mpi processes
-AZ_MPI_ARGS : The Optimal MPI command pinnings arguments (for openmpi, Intel MPI or Mvapich2)
+AZ_MPI_ARGS : File containing the Optimal MPI command pinnings arguments (for openmpi, Intel MPI or Mvapich2)
+```
 
 Add the following lines to your mpi run script to run 16 processes and 6 threads per process on a HB120-96rs_v3 (using hpcx or openmpi)
 

--- a/experimental/check_app_pinning_tool/readme.md
+++ b/experimental/check_app_pinning_tool/readme.md
@@ -1,7 +1,7 @@
 # HPC Application process/thread mapping/pinning checking tool
 
 Correct mapping/pinning of HPC Application processes/threads is critical for optimal performance.
-The HPC Application process/thread mapping/pinning checking tool has two main features, it allows you to quickly verify that the processes/threads associated with your HPC Application are mapped/pinned correctly/optimally or it can generate the MPI process/thread pinning syntax for OpenMPI/HPCX, Intel MPI and MVapich2 (Currently for HPC VM's based on AMD processors (HB (v1,v2 & v3) and NDv4). This tool shows you the virtual machine NUMA topology (i.e location of core id's, GPU's and NUMA domains), where the processes/threads associated with your HPC Application are mapped/pinned and warnings if they are not mapped/pinned optimally.
+The HPC Application process/thread mapping/pinning checking tool has three main features, it allows you to quickly verify that the processes/threads associated with your HPC Application are mapped/pinned correctly/optimally, it can generate the MPI process/thread pinning syntax for OpenMPI/HPCX, Intel MPI and Mvapich2 (Currently for HPC VM's based on AMD processors (HB (v1,v2 & v3) and NDv4) and you can use this tool directly in an mpi run script to pass and use the optimal mpi pinning arguments. This tool shows you the virtual machine NUMA topology (i.e location of core id's, GPU's and NUMA domains), where the processes/threads associated with your HPC Application are mapped/pinned and warnings if they are not mapped/pinned optimally.
 
 ## Prerequisites
 
@@ -222,3 +222,37 @@ PID          Threads           Running Threads   Last core id    Core id mapping
 Warning: threads corresponding to process 11588 are mapped to multiple L3cache(s) ([0, 1, 2, 3])
 [azureuser@cghb120v3 ~]$
 ```
+
+You can also use this pinning tool directly in an MPI script to pass and use the optimal pinning parameters to mpirun.
+The following files will be created in your current working directory.
+AZ_MPI_NP  : File containing the total number of mpi processes
+AZ_MPI_ARGS : The Optimal MPI command pinnings arguments (for openmpi, Intel MPI or Mvapich2)
+
+Add the following lines to your mpi run script to run 16 processes and 6 threads per process on a HB120-96rs_v3 (using hpcx or openmpi)
+
+```
+export OMP_NUM_THREADS=6
+check_app_pinning.py -pps -nv 1 -nppv 16 -ntpp $OMP_NUM_THREADS -mt openmpi
+AZ_MPI_NP=$(cat AZ_MPI_NP)
+AZ_MPI_ARGS=$(cat AZ_MPI_ARGS)
+
+mpirun  -np $AZ_MPI_NP $AZ_MPI_ARGS mpi_executable
+
+```
+>Note: AZ_MPI_NP=16 and AZ_MPI_ARGS="--bind-to l3cache --map-by ppr:4:numa -report-bindings"
+
+To run 96 processes on HB120-96rs_v3 (just comment out export OMP_NUM_THREADS=6) and change the check_app_pinning.py arguments to
+
+```
+check_app_pinning.py -pps -nv 1 -nppv 96 -mt openmpi
+```
+>Note:   AZ_MPI_NP=96 and AZ_MPI_ARGS="--bind-to cpulist:ordered --cpu-list 0,6,12,18,24,30,36,42,48,54,60,66,72,78,84,90,1,7,13,19,25,31,37,43,49,55,61,67,73,79,85,91,2,8,14,20,26,32,38,44,50,56,62,68,74,80,86,92,3,9,15,21,27,33,39,45,51,57,63,69,75,81,87,93,4,10,16,22,28,34,40,46,52,58,64,70,76,82,88,94,5,11,17,23,29,35,41,47,53,59,65,71,77,83,89,95 -report-bindings"
+
+
+To generate the appropraite MPI pinning syntax for Intel MPI or Mvapich2, just change the -mt argument (to "intel" or "mvapich2")
+
+To run 16 processes and 6 threads using Intel MPI on HB120-96rs_v3, just add -mt intel (instead of -mt openmpi)
+```
+check_app_pinning.py -pps -nv 1 -nppv 16 -ntpp $OMP_NUM_THREADS -mt intel
+```
+>Note: AZ_MPI_NP=16 and AZ_MPI_ARGS="-genv I_MPI_PIN_DOMAIN 6:compact -genv FI_PROVIDER mlx -genv I_MPI_COLL_EXTERNAL 1 -genv I_MPI_DEBUG 6"


### PR DESCRIPTION
- Support to use app pinning tool directly in an MPI run script (AZ_MPI_NP and AZ_MPI_ARGS will be defined to access the optimal MPI pinning parameters for openmpi, hpcx, intel MPI and mvapich2).

e.g. On HB120-96rs_v3, run 16 mpi process and 6 threads per process.

export OMP_NUM_THREADS=6
check_app_pinning.py -pps -nv 1 -nppv 16 -ntpp $OMP_NUM_THREADS -mt openmpi
AZ_MPI_NP=$(cat AZ_MPI_NP)
AZ_MPI_ARGS=$(cat AZ_MPI_ARGS)

mpirun  -n $AZ_MPI_NP $AZ_MPI_ARGS <mpi_executable>