### PR TITLE
Improve enroot installation 

### DIFF
--- a/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/common_functions.sh
+++ b/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/common_functions.sh
@@ -4,10 +4,6 @@ function is_slurm_controller() {
     ls /lib/systemd/system/ | grep -q slurmctld
 }
 
-function is_login_node() {
-    ! (ls /lib/systemd/system/ | grep -q slurm)
-}
-
 function is_compute_node() {
-	! is_slurm_controller && ! is_login_node
+	! is_slurm_controller
 }

--- a/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/common_functions.sh
+++ b/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/common_functions.sh
@@ -3,3 +3,11 @@
 function is_slurm_controller() {
     ls /lib/systemd/system/ | grep -q slurmctld
 }
+
+function is_login_node() {
+    ! (ls /lib/systemd/system/ | grep -q slurm)
+}
+
+function is_compute_node() {
+	! is_slurm_controller && ! is_login_node
+}

--- a/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/install_enroot.sh
+++ b/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/install_enroot.sh
@@ -12,6 +12,6 @@ if is_compute_node; then
     apt install -y $CYCLECLOUD_SPEC_PATH/files/enroot+caps_${ENROOT_VERSION}_amd64.deb
 
     # Install NVIDIA container support
-    apt-get install -y libnvidia-container1=1.14.4-1 libnvidia-container-tools=1.14.4-1
+    apt-get install -y libnvidia-container=1.14.4-1 libnvidia-container-tools=1.14.4-1
 
 fi

--- a/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/install_enroot.sh
+++ b/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/install_enroot.sh
@@ -5,7 +5,7 @@ source $CYCLECLOUD_SPEC_PATH/files/common_functions.sh
 ENROOT_VERSION='3.4.1-1'
 
 # Install enroot RPM packages on compute nodes
-if ! is_slurm_controller; then
+if is_compute_node; then
 
     # Install NVIDIA enroot
     apt install -y $CYCLECLOUD_SPEC_PATH/files/enroot_${ENROOT_VERSION}_amd64.deb

--- a/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/install_enroot.sh
+++ b/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/install_enroot.sh
@@ -12,6 +12,6 @@ if is_compute_node; then
     apt install -y $CYCLECLOUD_SPEC_PATH/files/enroot+caps_${ENROOT_VERSION}_amd64.deb
 
     # Install NVIDIA container support
-    apt-get install -y libnvidia-container1 libnvidia-container-tools
+    apt-get install -y libnvidia-container1=1.14.4-1 libnvidia-container-tools=1.14.4-1
 
 fi

--- a/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/install_enroot.sh
+++ b/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/install_enroot.sh
@@ -3,6 +3,7 @@
 source $CYCLECLOUD_SPEC_PATH/files/common_functions.sh
 
 ENROOT_VERSION='3.4.1-1'
+LIBNVIDIA_VERSION='1.14.4-1'
 
 # Install enroot RPM packages on compute nodes
 if is_compute_node; then
@@ -12,6 +13,6 @@ if is_compute_node; then
     apt install -y $CYCLECLOUD_SPEC_PATH/files/enroot+caps_${ENROOT_VERSION}_amd64.deb
 
     # Install NVIDIA container support
-    apt-get install -y libnvidia-container=1.14.3-1 libnvidia-container-tools=1.14.3-1
+    apt-get install -y --allow-change-held-packages libnvidia-container=${LIBNVIDIA_VERSION} libnvidia-container-tools=${LIBNVIDIA_VERSION}
 
 fi

--- a/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/install_enroot.sh
+++ b/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/install_enroot.sh
@@ -13,6 +13,6 @@ if is_compute_node; then
     apt install -y $CYCLECLOUD_SPEC_PATH/files/enroot+caps_${ENROOT_VERSION}_amd64.deb
 
     # Install NVIDIA container support
-    apt-get install -y --allow-change-held-packages libnvidia-container=${LIBNVIDIA_VERSION} libnvidia-container-tools=${LIBNVIDIA_VERSION}
+    apt-get install -y --allow-change-held-packages libnvidia-container1=${LIBNVIDIA_VERSION} libnvidia-container-tools=${LIBNVIDIA_VERSION}
 
 fi

--- a/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/install_enroot.sh
+++ b/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/install_enroot.sh
@@ -12,6 +12,6 @@ if is_compute_node; then
     apt install -y $CYCLECLOUD_SPEC_PATH/files/enroot+caps_${ENROOT_VERSION}_amd64.deb
 
     # Install NVIDIA container support
-    apt-get install -y libnvidia-container=1.14.4-1 libnvidia-container-tools=1.14.4-1
+    apt-get install -y libnvidia-container=1.14.3-1 libnvidia-container-tools=1.14.3-1
 
 fi

--- a/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/install_enroot_hooks.sh
+++ b/experimental/cc_slurm_pyxis_enroot/cc_slurm_pyxis_enroot/specs/default/cluster-init/files/install_enroot_hooks.sh
@@ -3,6 +3,6 @@
 source $CYCLECLOUD_SPEC_PATH/files/common_functions.sh
 
 # Install extra hooks for PMIx on compute nodes
-if ! is_slurm_controller; then
+if is_compute_node; then
    cp -fv /usr/share/enroot/hooks.d/50-slurm-pmi.sh /usr/share/enroot/hooks.d/50-slurm-pytorch.sh /etc/enroot/hooks.d
 fi


### PR DESCRIPTION
* Add additional logic to install Enroot only on compute nodes when login nodes are present in the cluster
* Lock libnvidia-container to latest version and force installation despite packages version being held in Ubuntu-HPC image