### PR TITLE
Add support for Ubuntu 22.04 in nhc-run script

### DIFF
--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/configure_nhc.sh
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/configure_nhc.sh
@@ -20,7 +20,6 @@ NHC_PROLOG=1
 NHC_EPILOG=0
 AUTOSCALING=0
 PROLOG_NOHOLD_REQUEUE=0
-PROLOG_RUN_NHC=0
 NHC_EXTRA_TEST_FILES="csc_nvidia_smi.nhc azure_cuda_bandwidth.nhc azure_gpu_app_clocks.nhc azure_gpu_ecc.nhc azure_gpu_persistence.nhc azure_ib_write_bw_gdr.nhc azure_nccl_allreduce_ib_loopback.nhc azure_ib_link_flapping.nhc azure_gpu_clock_throttling.nhc azure_cpu_drop_cache_mem.nhc azure_gpu_xid.nhc azure_nccl_allreduce.nhc azure_raid_health.nhc"
 
 source $CYCLECLOUD_SPEC_PATH/files/common_functions.sh
@@ -116,7 +115,7 @@ function update_slurm_prolog_epilog() {
          echo "Epilog=/sched/scripts/epilog.sh" >> $SLURM_CONF
       fi
    fi
-   echo "/sched/scripts/$script $prolog_epilog $PROLOG_RUN_NHC" >> /sched/scripts/${prolog_epilog}.sh
+   echo "/sched/scripts/$script $prolog_epilog" >> /sched/scripts/${prolog_epilog}.sh
 }
 
 

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/run_nhc.sh
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/run_nhc.sh
@@ -6,27 +6,19 @@ function set_detached_mode() {
 }
 
 function exclusive_node() {
-BASE_DIR="/sys/fs/cgroup/memory/slurm"
-cntu=0
-for dir in ${BASE_DIR}/uid_*
-do
-    if [ -d $dir ]; then
-       cntu=$((cntu+1))
-       if [[ $cntu -gt 1 ]]; then
-          return 1
-       fi
-       cntj=0
-       for job in ${dir}/job_*
-       do
-           if [ -d $job ]; then
-              cntj=$((cntj+1))
-              if [[ $cntj -gt 0 ]]; then
-                 return 1
-              fi
-           fi
-       done
-    fi
-done
+if [ -d "/sys/fs/cgroup/memory/slurm" ]; then
+   # Ubuntu 20.04
+   BASE_DIR="/sys/fs/cgroup/memory/slurm/uid_*"
+else
+   # Ubuntu 22.04
+   BASE_DIR="/sys/fs/cgroup/system.slice/${HOSTNAME}_slurmstepd.scope"
+fi
+
+NUM_JOBS=$(ls -ld ${BASE_DIR}/job* 2> /dev/null | wc -l)
+
+if [[ $NUM_JOBS -gt 0 ]]; then
+   return 1
+fi
 }
 
 prolog_epilog=$1

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/run_nhc.sh
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/run_nhc.sh
@@ -25,13 +25,13 @@ prolog_epilog=$1
 exclusive_node
 exclusive_node_rc=$?
 
-set_detached_mode 0
 NHC_RC=0
 if [ $exclusive_node_rc -eq 0 ]; then
+   set_detached_mode 0
    echo "[$prolog_eplilog] execute nhc" >> /var/log/nhc.log
    sudo /usr/sbin/nhc
    NHC_RC=$?
+   set_detached_mode 1
 fi
-set_detached_mode 1
 
 exit ${NHC_RC}

--- a/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/run_nhc.sh
+++ b/experimental/cc_slurm_nhc/cc_slurm_nhc/specs/default/cluster-init/files/run_nhc.sh
@@ -33,5 +33,3 @@ if [ $exclusive_node_rc -eq 0 ]; then
    NHC_RC=$?
    set_detached_mode 1
 fi
-
-exit ${NHC_RC}


### PR DESCRIPTION
In Ubuntu 22.04 the directory structure of cgroup has changed.

Changes in PR:
- Added support for Ubuntu 22.04 in `run_nhc.sh` and simplifies the logic of `exclusive_node` function
- Do not return NHC return code in `run_nhc.sh` to preserve the NHC drain reason in Slurm when `run_nhc.sh` runs as last command in epilog script. Currently all NHC drain reasons are replaced by generic epilog failure reason.
- Removed the unused parameter `PROLOG_RUN_NHC` in `configure_nhc.sh`
