### PR TITLE
Integrate GPU node health checks into AKS

### DIFF
--- a/experimental/aks_npd_draino/draino/manifest.yml
+++ b/experimental/aks_npd_draino/draino/manifest.yml
@@ -68,7 +68,7 @@ spec:
     spec:
       containers:
       # You'll want to change these labels and conditions to suit your deployment.
-      - command: [/draino, --skip-drain, --node-label=accelerator=nvidia, GpuCount, GpuNvlink, GpuXid]
+      - command: [/draino, --skip-drain, --node-label=accelerator=nvidia, GpuCount, GpuNvlink, GpuXid, GpuEcc]
         image: <YOUR ACR>.azurecr.io/draino:latest
         livenessProbe:
           httpGet: {path: /healthz, port: 10002}

--- a/experimental/aks_npd_draino/draino/manifest.yml
+++ b/experimental/aks_npd_draino/draino/manifest.yml
@@ -1,0 +1,77 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels: {component: draino}
+  name: draino
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    component: draino
+  name: draino
+rules:
+- apiGroups: ['']
+  resources: [events]
+  verbs: [create, patch, update]
+- apiGroups: ['']
+  resources: [nodes]
+  verbs: [get, watch, list, update, patch]
+- apiGroups: ['']
+  resources: [nodes/status]
+  verbs: [patch, watch, list, update, patch]
+- apiGroups: ['']
+  resources: [endpoints]
+  verbs: [get,watch, list, create, patch, update]
+- apiGroups: ['']
+  resources: [pods]
+  verbs: [get, watch, list]
+- apiGroups: ['']
+  resources: [pods/eviction]
+  verbs: [create]
+- apiGroups:
+    - extensions
+    - apps
+  resources: [daemonsets]
+  verbs: [get, watch, list]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels: {component: draino}
+  name: draino
+roleRef: {apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: draino}
+subjects:
+- {kind: ServiceAccount, name: draino, namespace: kube-system}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels: {component: draino}
+  name: draino
+  namespace: kube-system
+spec:
+  # Draino does not currently support locking/master election, so you should
+  # only run one draino at a time. Draino won't start draining nodes immediately
+  # so it's usually safe for multiple drainos to exist for a brief period of
+  # time.
+  replicas: 1
+  selector:
+    matchLabels: {component: draino}
+  template:
+    metadata:
+      labels: {component: draino}
+      name: draino
+      namespace: kube-system
+    spec:
+      containers:
+      # You'll want to change these labels and conditions to suit your deployment.
+      - command: [/draino, --skip-drain, --node-label=accelerator=nvidia, GpuCount, GpuNvlink, GpuXid]
+        image: <YOUR ACR>.azurecr.io/draino:latest
+        livenessProbe:
+          httpGet: {path: /healthz, port: 10002}
+          initialDelaySeconds: 30
+        name: draino
+      serviceAccountName: draino

--- a/experimental/aks_npd_draino/npd/Dockerfile
+++ b/experimental/aks_npd_draino/npd/Dockerfile
@@ -1,0 +1,60 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ARG BASEIMAGE
+
+# "builder-base" can be overriden using dockerb buildx's --build-context flag,
+# by users who want to use a different images for the builder. E.g. if you need to use an older OS
+# to avoid dependencies on very recent glibc versions.
+# E.g. of the param: --build-context builder-base=docker-image://golang:<something>@sha256:<something>
+# Must override builder-base, not builder, since the latter is referred to later in the file and so must not be
+# directly replaced. See here, and note that "stage" parameter mentioned there has been renamed to
+# "build-context": https://github.com/docker/buildx/pull/904#issuecomment-1005871838
+FROM nvcr.io/nvidia/pytorch:23.03-py3 as builder-base
+FROM builder-base as builder
+LABEL maintainer="Andy Xie <andy.xning@gmail.com>"
+
+ARG TARGETARCH
+
+COPY go1.22.4.linux-amd64.tar.gz .
+RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.22.4.linux-amd64.tar.gz
+
+ENV GOPATH /usr/local/go
+ENV PATH $GOPATH/bin:$PATH
+
+RUN apt-get update --fix-missing && apt-get --yes install libsystemd-dev gcc-aarch64-linux-gnu
+RUN go version
+
+COPY . /gopath/src/k8s.io/node-problem-detector/
+WORKDIR /gopath/src/k8s.io/node-problem-detector
+RUN GOARCH=${TARGETARCH} make bin/node-problem-detector bin/health-checker bin/log-counter
+
+ARG BASEIMAGE
+FROM --platform=${TARGETPLATFORM} ${BASEIMAGE}
+
+LABEL maintainer="Random Liu <lantaol@google.com>"
+
+#RUN clean-install util-linux bash libsystemd-dev
+
+# Avoid symlink of /etc/localtime.
+RUN test -h /etc/localtime && rm -f /etc/localtime && cp /usr/share/zoneinfo/UTC /etc/localtime || true
+
+COPY --from=builder /gopath/src/k8s.io/node-problem-detector/bin/node-problem-detector /node-problem-detector
+
+ARG LOGCOUNTER
+COPY --from=builder /gopath/src/k8s.io/node-problem-detector/bin/health-checker /gopath/src/k8s.io/node-problem-detector/${LOGCOUNTER} /home/kubernetes/bin/
+
+COPY --from=builder /gopath/src/k8s.io/node-problem-detector/config/ /config
+COPY --from=builder /gopath/src/k8s.io/node-problem-detector/config/plugin/*.sh /config/plugin
+WORKDIR /
+ENTRYPOINT ["/node-problem-detector", "--config.custom-plugin-monitor=/config/custom-plugin-gpu-count.json"]

--- a/experimental/aks_npd_draino/npd/Makefile
+++ b/experimental/aks_npd_draino/npd/Makefile
@@ -1,0 +1,306 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build the node-problem-detector image.
+
+.PHONY: all \
+        vet fmt version test e2e-test \
+        build-binaries build-container build-tar build \
+        docker-builder build-in-docker \
+        push-container push-tar push release clean depup \
+        print-tar-sha-md5
+
+all: build
+
+# PLATFORMS is the set of OS_ARCH that NPD can build against.
+LINUX_PLATFORMS=linux_amd64
+DOCKER_PLATFORMS=linux/amd64
+PLATFORMS=$(LINUX_PLATFORMS) windows_amd64
+
+# VERSION is the version of the binary.
+VERSION?=$(shell if [ -d .git ]; then echo `git describe --tags --dirty`; else echo "UNKNOWN"; fi)
+
+# TAG is the tag of the container image, default to binary version.
+TAG?=$(VERSION)_<UNIQUE NUMBER>
+
+# REGISTRY is the container registry to push into.
+#REGISTRY?=gcr.io/k8s-staging-npd
+REGISTRY?=<YOUR ACR>.azurecr.io/k8s-staging-npd
+
+# UPLOAD_PATH is the cloud storage path to upload release tar.
+UPLOAD_PATH?=gs://kubernetes-release
+# Trim the trailing '/' in the path
+UPLOAD_PATH:=$(shell echo $(UPLOAD_PATH) | sed '$$s/\/*$$//')
+
+# PKG is the package name of node problem detector repo.
+PKG:=k8s.io/node-problem-detector
+
+# PKG_SOURCES are all the go source code.
+ifeq ($(OS),Windows_NT)
+PKG_SOURCES:=
+# TODO: File change detection does not work in Windows.
+else
+PKG_SOURCES:=$(shell find pkg cmd -name '*.go')
+endif
+
+# PARALLEL specifies the number of parallel test nodes to run for e2e tests.
+PARALLEL?=3
+
+NPD_NAME_VERSION?=node-problem-detector-$(VERSION)
+# TARBALL is the name of release tar. Include binary version by default.
+TARBALL=$(NPD_NAME_VERSION).tar.gz
+
+# IMAGE is the image name of the node problem detector container image.
+IMAGE:=$(REGISTRY)/node-problem-detector:$(TAG)
+
+# ENABLE_JOURNALD enables build journald support or not. Building journald
+# support needs libsystemd-dev or libsystemd-journal-dev.
+ENABLE_JOURNALD?=1
+
+ifeq ($(shell go env GOHOSTOS), darwin)
+ENABLE_JOURNALD=0
+else ifeq ($(shell go env GOHOSTOS), windows)
+ENABLE_JOURNALD=0
+endif
+
+# Set default base image to Debian 12 (Bookworm)
+#BASEIMAGE:=registry.k8s.io/build-image/debian-base:bookworm-v1.0.3
+BASEIMAGE:=nvcr.io/nvidia/pytorch:23.03-py3
+
+# Disable cgo by default to make the binary statically linked.
+CGO_ENABLED:=0
+
+# Set default Go architecture to AMD64.
+GOARCH ?= amd64
+
+# Construct the "-tags" parameter used by "go build".
+BUILD_TAGS?=
+
+LINUX_BUILD_TAGS = $(BUILD_TAGS)
+WINDOWS_BUILD_TAGS = $(BUILD_TAGS)
+
+ifeq ($(OS),Windows_NT)
+HOST_PLATFORM_BUILD_TAGS = $(WINDOWS_BUILD_TAGS)
+else
+HOST_PLATFORM_BUILD_TAGS = $(LINUX_BUILD_TAGS)
+endif
+
+ifeq ($(ENABLE_JOURNALD), 1)
+        # Enable journald build tag.
+        LINUX_BUILD_TAGS := journald $(BUILD_TAGS)
+        # Enable cgo because sdjournal needs cgo to compile. The binary will be
+        # dynamically linked if CGO_ENABLED is enabled. This is fine because fedora
+        # already has necessary dynamic library. We can not use `-extldflags "-static"`
+        # here, because go-systemd uses dlopen, and dlopen will not work properly in a
+        # statically linked application.
+        CGO_ENABLED:=1
+        LOGCOUNTER=./bin/log-counter
+else
+        # Hack: Don't copy over log-counter, use a wildcard path that shouldn't match
+        # anything in COPY command.
+        LOGCOUNTER=*dont-include-log-counter
+endif
+
+vet:
+        go list -tags "$(HOST_PLATFORM_BUILD_TAGS)" ./... | \
+                grep -v "./vendor/*" | \
+                xargs go vet -tags "$(HOST_PLATFORM_BUILD_TAGS)"
+
+fmt:
+        find . -type f -name "*.go" | grep -v "./vendor/*" | xargs gofmt -s -w -l
+
+version:
+        @echo $(VERSION)
+
+BINARIES = bin/node-problem-detector bin/health-checker test/bin/problem-maker
+BINARIES_LINUX_ONLY =
+ifeq ($(ENABLE_JOURNALD), 1)
+        BINARIES_LINUX_ONLY += bin/log-counter
+endif
+
+ALL_BINARIES = $(foreach binary, $(BINARIES) $(BINARIES_LINUX_ONLY), ./$(binary)) \
+  $(foreach platform, $(LINUX_PLATFORMS), $(foreach binary, $(BINARIES) $(BINARIES_LINUX_ONLY), output/$(platform)/$(binary))) \
+  $(foreach binary, $(BINARIES), output/windows_amd64/$(binary).exe)
+ALL_TARBALLS = $(foreach platform, $(PLATFORMS), $(NPD_NAME_VERSION)-$(platform).tar.gz)
+
+output/windows_amd64/bin/%.exe: $(PKG_SOURCES)
+        GOOS=windows GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) go build \
+                -o $@ \
+                -ldflags '-X $(PKG)/pkg/version.version=$(VERSION)' \
+                -tags "$(WINDOWS_BUILD_TAGS)" \
+                ./cmd/$(subst -,,$*)
+        touch $@
+
+output/windows_amd64/test/bin/%.exe: $(PKG_SOURCES)
+        cd test && \
+        GOOS=windows GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) go build \
+                -o ../$@ \
+                -tags "$(WINDOWS_BUILD_TAGS)" \
+                ./e2e/$(subst -,,$*)
+
+output/linux_amd64/bin/%: $(PKG_SOURCES)
+        GOOS=linux GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) \
+          CC=x86_64-linux-gnu-gcc go build \
+                -o $@ \
+                -ldflags '-X $(PKG)/pkg/version.version=$(VERSION)' \
+                -tags "$(LINUX_BUILD_TAGS)" \
+                ./cmd/$(subst -,,$*)
+        touch $@
+
+output/linux_amd64/test/bin/%: $(PKG_SOURCES)
+        cd test && \
+        GOOS=linux GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) \
+          CC=x86_64-linux-gnu-gcc go build \
+                -o ../$@ \
+                -tags "$(LINUX_BUILD_TAGS)" \
+                ./e2e/$(subst -,,$*)
+
+output/linux_arm64/bin/%: $(PKG_SOURCES)
+        GOOS=linux GOARCH=arm64 CGO_ENABLED=$(CGO_ENABLED) \
+          CC=aarch64-linux-gnu-gcc go build \
+                -o $@ \
+                -ldflags '-X $(PKG)/pkg/version.version=$(VERSION)' \
+                -tags "$(LINUX_BUILD_TAGS)" \
+                ./cmd/$(subst -,,$*)
+        touch $@
+
+output/linux_arm64/test/bin/%: $(PKG_SOURCES)
+        cd test && \
+        GOOS=linux GOARCH=arm64 CGO_ENABLED=$(CGO_ENABLED) \
+          CC=aarch64-linux-gnu-gcc go build \
+                -o ../$@ \
+                -tags "$(LINUX_BUILD_TAGS)" \
+                ./e2e/$(subst -,,$*)
+
+# In the future these targets should be deprecated.
+./bin/log-counter: $(PKG_SOURCES)
+ifeq ($(ENABLE_JOURNALD), 1)
+        CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=$(GOARCH) go build \
+                -o bin/log-counter \
+                -ldflags '-X $(PKG)/pkg/version.version=$(VERSION)' \
+                -tags "$(LINUX_BUILD_TAGS)" \
+                cmd/logcounter/log_counter.go
+else
+        echo "Warning: log-counter requires journald, skipping."
+endif
+
+./bin/node-problem-detector: $(PKG_SOURCES)
+        CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=$(GOARCH) go build \
+                -o bin/node-problem-detector \
+                -ldflags '-X $(PKG)/pkg/version.version=$(VERSION)' \
+                -tags "$(LINUX_BUILD_TAGS)" \
+                ./cmd/nodeproblemdetector
+
+./test/bin/problem-maker: $(PKG_SOURCES)
+        cd test && \
+        CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=$(GOARCH) go build \
+                -o bin/problem-maker \
+                -tags "$(LINUX_BUILD_TAGS)" \
+                ./e2e/problemmaker/problem_maker.go
+
+./bin/health-checker: $(PKG_SOURCES)
+        CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=$(GOARCH) go build \
+                -o bin/health-checker \
+                -ldflags '-X $(PKG)/pkg/version.version=$(VERSION)' \
+                -tags "$(LINUX_BUILD_TAGS)" \
+                cmd/healthchecker/health_checker.go
+
+test: vet fmt
+        go test -timeout=1m -v -race -short -tags "$(HOST_PLATFORM_BUILD_TAGS)" ./...
+
+e2e-test: vet fmt build-tar
+        cd test && \
+        go run github.com/onsi/ginkgo/ginkgo -nodes=$(PARALLEL) -timeout=10m -v -tags "$(HOST_PLATFORM_BUILD_TAGS)" -stream \
+        ./e2e/metriconly/... -- \
+        -project=$(PROJECT) -zone=$(ZONE) \
+        -image=$(VM_IMAGE) -image-family=$(IMAGE_FAMILY) -image-project=$(IMAGE_PROJECT) \
+        -ssh-user=$(SSH_USER) -ssh-key=$(SSH_KEY) \
+        -npd-build-tar=`pwd`/../$(TARBALL) \
+        -boskos-project-type=$(BOSKOS_PROJECT_TYPE) -job-name=$(JOB_NAME) \
+        -artifacts-dir=$(ARTIFACTS)
+
+$(NPD_NAME_VERSION)-%.tar.gz: $(ALL_BINARIES) test/e2e-install.sh
+        mkdir -p output/$*/ output/$*/test/
+        cp -r config/ output/$*/
+        cp test/e2e-install.sh output/$*/test/e2e-install.sh
+        (cd output/$*/ && tar -zcvf ../../$@ *)
+        sha512sum $@ > $@.sha512
+
+build-binaries: $(ALL_BINARIES)
+
+build-container: clean Dockerfile
+        docker buildx create --platform $(DOCKER_PLATFORMS) --use
+        docker buildx build --platform $(DOCKER_PLATFORMS) -t $(IMAGE) --build-arg BASEIMAGE=$(BASEIMAGE) --build-arg LOGCOUNTER=$(LOGCOUNTER) .
+
+$(TARBALL): ./bin/node-problem-detector ./bin/log-counter ./bin/health-checker ./test/bin/problem-maker
+        tar -zcvf $(TARBALL) bin/ config/ test/e2e-install.sh test/bin/problem-maker
+        sha1sum $(TARBALL)
+        md5sum $(TARBALL)
+
+build-tar: $(TARBALL) $(ALL_TARBALLS)
+
+build: build-container build-tar
+
+docker-builder:
+        docker build -t npd-builder . --target=builder --build-arg BASEIMAGE=$(BASEIMAGE)
+
+build-in-docker: clean docker-builder
+        docker run \
+                -v `pwd`:/gopath/src/k8s.io/node-problem-detector/ npd-builder:latest bash \
+                -c 'cd /gopath/src/k8s.io/node-problem-detector/ && make build-binaries'
+
+push-container: build-container
+        # So we can push to docker hub by setting REGISTRY
+ifneq (,$(findstring gcr.io,$(REGISTRY)))
+        gcloud auth configure-docker
+endif
+        # Build should be cached from build-container
+        docker buildx build --push --platform $(DOCKER_PLATFORMS) -t $(IMAGE) --build-arg BASEIMAGE=$(BASEIMAGE) --build-arg LOGCOUNTER=$(LOGCOUNTER) .
+
+push-tar: build-tar
+        gsutil cp $(TARBALL) $(UPLOAD_PATH)/node-problem-detector/
+        gsutil cp node-problem-detector-$(VERSION)-*.tar.gz* $(UPLOAD_PATH)/node-problem-detector/
+
+# `make push` is used by presubmit and CI jobs.
+push: push-container push-tar
+
+# `make release` is used when releasing a new NPD version.
+release: push-container build-tar print-tar-sha-md5
+
+print-tar-sha-md5: build-tar
+        ./hack/print-tar-sha-md5.sh $(VERSION)
+
+coverage.out:
+        rm -f coverage.out
+        go test -coverprofile=coverage.out -timeout=1m -v -short ./...
+
+clean:
+        rm -rf bin/
+        rm -rf test/bin/
+        rm -f node-problem-detector-*.tar.gz*
+        rm -rf output/
+        rm -f coverage.out
+
+.PHONY: gomod
+gomod:
+        go mod tidy
+        go mod vendor
+        cd test; go mod tidy
+
+.PHONY: goget
+goget:
+        go get $(shell go list -f '{{if not (or .Main .Indirect)}}{{.Path}}{{end}}' -mod=mod -m all)
+
+.PHONY: depup
+depup: goget gomod

--- a/experimental/aks_npd_draino/npd/deployment/node-problem-detector-config.yaml
+++ b/experimental/aks_npd_draino/npd/deployment/node-problem-detector-config.yaml
@@ -418,7 +418,7 @@ data:
     }
   check_gpu_ecc.sh: |
     #!/bin/bash
-    # This plugin checks GPU XID errors
+    # This plugin checks for GPU ECC errors
     readonly OK=0
     readonly NONOK=1
     readonly UNKNOWN=2

--- a/experimental/aks_npd_draino/npd/deployment/node-problem-detector-config.yaml
+++ b/experimental/aks_npd_draino/npd/deployment/node-problem-detector-config.yaml
@@ -1,0 +1,387 @@
+apiVersion: v1
+data:
+  kernel-monitor.json: |
+    {
+        "plugin": "kmsg",
+        "logPath": "/dev/kmsg",
+        "lookback": "5m",
+        "bufferSize": 10,
+        "source": "kernel-monitor",
+        "conditions": [
+            {
+                "type": "KernelDeadlock",
+                "reason": "KernelHasNoDeadlock",
+                "message": "kernel has no deadlock"
+            },
+            {
+                "type": "ReadonlyFilesystem",
+                "reason": "FilesystemIsNotReadOnly",
+                "message": "Filesystem is not read-only"
+            }
+        ],
+        "rules": [
+            {
+                "type": "temporary",
+                "reason": "OOMKilling",
+                "pattern": "Kill process \\d+ (.+) score \\d+ or sacrifice child\\nKilled process \\d+ (.+) total-vm:\\d+kB, anon-rss:\\d+kB, file-rss:\\d+kB.*"
+            },
+            {
+                "type": "temporary",
+                "reason": "TaskHung",
+                "pattern": "task \\S+:\\w+ blocked for more than \\w+ seconds\\."
+            },
+            {
+                "type": "temporary",
+                "reason": "UnregisterNetDevice",
+                "pattern": "unregister_netdevice: waiting for \\w+ to become free. Usage count = \\d+"
+            },
+            {
+                "type": "temporary",
+                "reason": "KernelOops",
+                "pattern": "BUG: unable to handle kernel NULL pointer dereference at .*"
+            },
+            {
+                "type": "temporary",
+                "reason": "KernelOops",
+                "pattern": "divide error: 0000 \\[#\\d+\\] SMP"
+            },
+            {
+                        "type": "temporary",
+                        "reason": "MemoryReadError",
+                        "pattern": "CE memory read error .*"
+            },
+            {
+                "type": "permanent",
+                "condition": "KernelDeadlock",
+                "reason": "DockerHung",
+                "pattern": "task docker:\\w+ blocked for more than \\w+ seconds\\."
+            },
+            {
+                "type": "permanent",
+                "condition": "ReadonlyFilesystem",
+                "reason": "FilesystemIsReadOnly",
+                "pattern": "Remounting filesystem read-only"
+            }
+        ]
+    }
+  docker-monitor.json: |
+    {
+        "plugin": "journald",
+        "pluginConfig": {
+            "source": "dockerd"
+        },
+        "logPath": "/var/log/journal",
+        "lookback": "5m",
+        "bufferSize": 10,
+        "source": "docker-monitor",
+        "conditions": [],
+        "rules": [
+            {
+                "type": "temporary",
+                "reason": "CorruptDockerImage",
+                "pattern": "Error trying v2 registry: failed to register layer: rename /var/lib/docker/image/(.+) /var/lib/docker/image/(.+): directory not empty.*"
+            }
+        ]
+    }
+  custom-plugin-monitor.json: |
+    {
+      "plugin": "custom",
+      "pluginConfig": {
+        "invoke_interval": "30s",
+        "timeout": "15s",
+        "max_output_length": 80,
+        "concurrency": 3,
+        "enable_message_change_based_condition_update": false
+      },
+      "source": "ntp-custom-plugin-monitor",
+      "metricsReporting": true,
+      "conditions": [
+        {
+          "type": "NTPProblem",
+          "reason": "NTPIsUp",
+          "message": "ntp service is up"
+        }
+      ],
+      "rules": [
+        {
+          "type": "temporary",
+          "reason": "NTPIsDown",
+          "path": "./config/plugin/check_ntp.sh",
+          "timeout": "10s"
+        },
+        {
+          "type": "permanent",
+          "condition": "NTPProblem",
+          "reason": "NTPIsDown",
+          "path": "./config/plugin/check_ntp.sh",
+          "timeout": "10s"
+        }
+      ]
+    }
+  check_ntp.sh: |
+    #!/bin/bash
+
+    # This plugin checks if the ntp service is running under systemd.
+    # NOTE: This is only an example for systemd services.
+
+    readonly OK=0
+    readonly NONOK=1
+    readonly UNKNOWN=2
+
+    readonly SERVICE='ntp.service'
+
+    # Check systemd cmd present
+    if ! command -v systemctl >/dev/null; then
+      echo "Could not find 'systemctl' - require systemd"
+      exit $UNKNOWN
+    fi
+
+    # Return success if service active (i.e. running)
+    if systemctl -q is-active "$SERVICE"; then
+      echo "$SERVICE is running"
+      exit $OK
+    else
+    # Does not differentiate stopped/failed service from non-existent
+      echo "$SERVICE is not running"
+      exit $NONOK
+    fi
+  custom-plugin-gpu-count.json: |
+    {
+      "plugin": "custom",
+      "pluginConfig": {
+      "invoke_interval": "30s",
+      "timeout": "20s",
+      "max_output_length": 80,
+      "concurrency": 3,
+      "enable_message_change_based_condition_update": false
+      },
+      "source": "custom-plugin-gpu-count",
+      "metricsReporting": false,
+      "conditions": [
+        {
+          "type": "GpuCount",
+          "reason": "GpuCountGood",
+          "message": "GPU count is correct"
+        }
+      ],
+      "rules": [
+        {
+          "type": "temporary",
+          "reason": "GpuCountBad",
+          "path": "./config/plugin/check_gpu_count.sh",
+          "timeout": "5s"
+        },
+        {
+          "type": "permanent",
+          "condition": "GpuCount",
+          "reason": "GpuCountBad",
+          "path": "./config/plugin/check_gpu_count.sh",
+          "timeout": "5s"
+        }
+      ]
+    }
+  check_gpu_count.sh: |
+    #!/bin/bash
+
+    # This plugin checks if is the VM has the correct number of GPU's
+
+    readonly OK=0
+    readonly NONOK=1
+    readonly UNKNOWN=2
+
+    readonly EXPECTED_NUM_GPU=8
+    readonly GPU_TYPE="nvidia"
+
+
+    if [ "$GPU_TYPE" == "rocm" ]; then
+       gpu_count=$(rocm-smi -l | grep 'GPU' | wc -l)
+    else
+       gpu_count=$(nvidia-smi --list-gpus | wc -l)
+    fi
+
+    if [ "$gpu_count" -ne "$EXPECTED_NUM_GPU" ]; then
+       echo "Expected to see $EXPECTED_NUM_GPU but found $gpu_count. FaultCode: NHC2009"
+       exit $NONOK
+    else
+       echo "Expected $EXPECTED_NUM_GPU and found $gpu_count"
+       exit $OK
+    fi
+  custom-plugin-gpu-nvlink.json: |
+    {
+      "plugin": "custom",
+      "pluginConfig": {
+      "invoke_interval": "60s",
+      "timeout": "35s",
+      "max_output_length": 80,
+      "concurrency": 3,
+      "enable_message_change_based_condition_update": false
+      },
+      "source": "custom-plugin-gpu-nvlink",
+      "metricsReporting": false,
+      "conditions": [
+        {
+          "type": "GpuNvlink",
+          "reason": "GpuNvlinkGood",
+          "message": "GPU NVlink is ok"
+        }
+      ],
+      "rules": [
+        {
+          "type": "temporary",
+          "reason": "GpuNvlinkBad",
+          "path": "./config/plugin/check_gpu_nvlink.sh",
+          "timeout": "20s"
+        },
+        {
+          "type": "permanent",
+          "condition": "GpuNvlink",
+          "reason": "GpuNvlinkBad",
+          "path": "./config/plugin/check_gpu_nvlink.sh",
+          "timeout": "20s"
+        }
+      ]
+    }
+  check_gpu_nvlink.sh: |
+    #!/bin/bash
+    # This plugin checks if is the GPU NVlink is working correctly.
+
+    readonly OK=0
+    readonly NONOK=1
+    readonly UNKNOWN=2
+
+    readonly EXPECTED_NUM_GPU=8
+
+
+    # Check if nvlink is enabled
+    num_gpus=$EXPECTED_NUM_GPU
+
+    nvlink_status=$(nvidia-smi nvlink --status)
+    if [ $? -ne 0 ]; then
+       echo "Failed to get NVLINK status with error code $?. FaultCode: NHC2016"
+                exit $NONOK
+    fi
+    if [ -z "$nvlink_status" ]; then
+       echo "NVLINK is not enabled"
+       exit $OK
+    fi
+    for ((i=0; i<num_gpus; i++)); do
+        gpu_id=$i
+    # Run nvlink command
+        nvlink_output=$(nvidia-smi nvlink -s -i $gpu_id)
+        if [ $? -ne 0 ]; then
+           echo "Failed to get NVLINK status with error code $?. FaultCode: NHC2016"
+           exit $NONOK
+        fi
+     # Check for inactive links
+        if [[ $nvlink_output == *"inactive"* ]]; then
+     # Extract and display the information about inactive links
+           inactive_links=$(echo "$nvlink_output" | grep "Link" | grep "<inactive>" | sed 's/Link \([0-9]*\): <inactive>/Link \1: Inactive/')
+           echo "GPU $gpu_id has nvlinks inactive: $inactive_links. FaultCode: NHC2016"
+           exit 1
+        elif [[ $nvlink_output == *"all links are inActive"* ]]; then
+             echo "GPU $gpu_id has all nvlinks inactive"
+             exit 1
+        else
+             echo "GPU $gpu_id has all nvlinks active."
+             exit $OK
+        fi
+        echo "NVLink is enabled and GPU $gpu_id has all nvlinks active"
+        exit $OK
+    done
+
+    exit 0
+  custom-plugin-gpu-xid.json: |
+    {
+      "plugin": "custom",
+      "pluginConfig": {
+      "invoke_interval": "60s",
+      "timeout": "35s",
+      "max_output_length": 80,
+      "concurrency": 3,
+      "enable_message_change_based_condition_update": false
+      },
+      "source": "custom-plugin-gpu-xid",
+      "metricsReporting": false,
+      "conditions": [
+        {
+          "type": "GpuXid",
+          "reason": "GpuXidGood",
+          "message": "GPU XID is ok"
+        }
+      ],
+      "rules": [
+        {
+          "type": "temporary",
+          "reason": "GpuXidBad",
+          "path": "./config/plugin/check_gpu_xid.sh",
+          "timeout": "20s"
+        },
+        {
+          "type": "permanent",
+          "condition": "GpuXid",
+          "reason": "GpuXidBad",
+          "path": "./config/plugin/check_gpu_xid.sh",
+          "timeout": "20s"
+        }
+      ]
+    }
+  check_gpu_xid.sh: |
+    #!/bin/bash
+    # This plugin checks GPU XID errors
+    readonly OK=0
+    readonly NONOK=1
+    readonly UNKNOWN=2
+
+    # time threshold in hours
+    readonly time_threshold=2
+    readonly logfile="/var/log/azakslog"
+    readonly kernel_log="var/log/syslog"
+    readonly XID_EC="48 56 57 58 62 63 64 65 68 69 73 74 79 80 81 92 119 120"
+    readonly GPU_XID_TEST="GPU Xid errors detected"
+
+
+    if [[ ! -f $kernel_log ]]; then
+       echo "$kernel_log not found. Skipping GPU Xid error test."
+       exit $NONOK
+    fi
+
+    # check for any xid errors
+    grep -q "Xid" $kernel_log
+    RC=$?
+    if [ $RC == 0 ]; then
+       for XID in $XID_EC; do
+           xid_found_line=$(grep "Xid.*: $XID," $kernel_log  | tail -n 1)
+           if [ "$xid_found_line" != "" ]; then
+              logXid=$(echo "$xid_found_line" | awk -F ',' '{print $1}' )
+              logMsg="Found XID: $logXid"
+              log_date="$(echo "$logXid" | awk '{print $1, $2, $3}') $(date +"%Y")"
+              log_date=$(date -d "$log_date" +"%s")
+              current_ts=$(date +"%s")
+              diff=$(( (current_ts - log_date) / 3600 ))
+
+              if [ "$diff" -le $time_threshold ]; then
+    # check if the XID has been reported in the log before
+                 if grep -qF "$logMsg" "$logfile"; then
+                    echo "This XID has been reported before: $logXid."
+                 else
+                    echo "$logMsg" >> $logfile
+                    echo "$GPU_XID_TEST: $xid_found_line. FaultCode: NHC2001"
+                    exit $NONOK
+                 fi
+              else
+                echo "Xid older than $time_threshold hours: $diff hours. Skipping this XID error: $logXid." >> $logfile
+              fi
+
+           else
+             echo "No GPU Xid $XID error found in kernel log"
+             exit $OK
+           fi
+      done
+    fi
+
+    echo "GPU XID error check passed."
+    exit $OK
+kind: ConfigMap
+metadata:
+  name: node-problem-detector-config
+  namespace: kube-system

--- a/experimental/aks_npd_draino/npd/deployment/node-problem-detector-config.yaml
+++ b/experimental/aks_npd_draino/npd/deployment/node-problem-detector-config.yaml
@@ -396,7 +396,7 @@ data:
       "conditions": [
         {
           "type": "GpuEcc",
-          "reason": "GpuEccdGood",
+          "reason": "GpuEccGood",
           "message": "GPU ECC is ok"
         }
       ],
@@ -418,7 +418,7 @@ data:
     }
   check_gpu_ecc.sh: |
     #!/bin/bash
-    # This plugin checks for GPU ECC errors
+    # This plugin checks GPU XID errors
     readonly OK=0
     readonly NONOK=1
     readonly UNKNOWN=2
@@ -577,6 +577,135 @@ data:
        echo "ECC checks passed"
        exit $NONOK
     }
+  custom-plugin-ib.json: |
+    {
+      "plugin": "custom",
+      "pluginConfig": {
+      "invoke_interval": "60s",
+      "timeout": "35s",
+      "max_output_length": 80,
+      "concurrency": 3,
+      "enable_message_change_based_condition_update": false
+      },
+      "source": "custom-plugin-ib",
+      "metricsReporting": false,
+      "conditions": [
+        {
+          "type": "IbDev",
+          "reason": "IbDevGood",
+          "message": "IB devices are ok"
+        }
+      ],
+      "rules": [
+        {
+          "type": "temporary",
+          "reason": "IbDevBad",
+          "path": "./config/plugin/check_ib.sh",
+          "timeout": "20s"
+        },
+        {
+          "type": "permanent",
+          "condition": "IbDev",
+          "reason": "IbDevBad",
+          "path": "./config/plugin/check_ib.sh",
+          "timeout": "20s"
+        }
+      ]
+    }
+  check_ib.sh: |
+    #!/bin/bash
+    # This plugin checks IB.devices.
+    readonly EXPECTED_IB_Gbps=200
+    readonly EXPECTED_IB_DEVS="mlx5_0:1 mlx5_1:1 mlx5_2:1 mlx5_3:1 mlx5_4:1 mlx5_5:1 mlx5_6:1 mlx5_7:1"
+
+    HW_IB_STATE=( )
+    HW_IB_PHYS_STATE=()
+    HW_IB_RATE=( )
+    HW_IB_DEV=()
+
+    function gather_ib_data() {
+        local IFS LINE CORES SIBLINGS MHZ PROCESSOR PHYS_ID PORT INDEX DEV
+        local -a FIELD PHYS_IDS IB_PORTS
+
+
+    # Gather IB info
+        set +f
+        IFS=''
+        IB_PORTS=( /sys/class/infiniband/*/ports/* )
+        IFS=$' \t\n'
+        set -f
+        for PORT in "${IB_PORTS[@]}" ; do
+            test -e "$PORT" || break
+            INDEX=${#HW_IB_STATE[*]}
+            IFS=' :'
+            read LINE < $PORT/state
+            FIELD=( $LINE )
+            HW_IB_STATE[$INDEX]=${FIELD[1]}
+            read LINE < $PORT/phys_state
+            FIELD=( $LINE )
+            HW_IB_PHYS_STATE[$INDEX]=${FIELD[1]}
+            read LINE < $PORT/rate
+            FIELD=( $LINE )
+            HW_IB_RATE[$INDEX]=${FIELD[0]}
+            IFS=' /'
+            arr=( $PORT )
+            HW_IB_DEV[$INDEX]="${arr[4]}:${arr[6]}"
+            IFS=$' \t\n'
+    #        echo "Found ${HW_IB_STATE[$INDEX]} (${HW_IB_PHYS_STATE[$INDEX]}) IB Port ${HW_IB_DEV[$INDEX]} (${HW_IB_RATE[$INDEX]} Gb/sec)"
+        done
+        export HW_IB_STATE HW_IB_PHYS_STATE HW_IB_RATE
+
+    # Check if user-leved mad driver loaded and IB diag tools will succeed to run
+        if [[ -f /sys/class/infiniband_mad/abi_version ]]; then
+           read HW_IB_UMAD_ABI_VER < /sys/class/infiniband_mad/abi_version
+        else
+           HW_IB_UMAD_ABI_VER=0
+        fi
+        export HW_IB_UMAD_ABI_VER
+    }
+    # Check if IB state, phys_state, and rate ($1) all match.
+    function check_ib() {
+        local STATE="ACTIVE"
+        local PHYS_STATE="LinkUp"
+        local RATE="$1"
+        local DEV="$2"
+        local i
+
+        if [[ ${#HW_IB_STATE[*]} -eq 0 ]]; then
+           gather_ib_data
+        fi
+
+        if [[ $HW_IB_UMAD_ABI_VER -eq 0 ]]; then
+           echo "Version mismatch between kernel OFED drivers and userspace OFED libraries."
+           exit 1
+        fi
+
+        for ((i=0; i < ${#HW_IB_STATE[*]}; i++)); do
+            if [[ "${HW_IB_STATE[$i]}" == "$STATE" && "${HW_IB_PHYS_STATE[$i]}" == "$PHYS_STATE" ]]; then
+               if [[ (-z "$DEV" || "${HW_IB_DEV[$i]}" == "$DEV") && (-z "$RATE" || "${HW_IB_RATE[$i]}" == "$RATE") ]]; then
+                  return 0
+               fi
+            fi
+        done
+
+        if [[ -n "$DEV" ]]; then
+           DEV=" $DEV"
+        fi
+        if [[ -n "$RATE" ]]; then
+           RATE=" $RATE Gb/sec"
+        fi
+
+        echo "No IB port$DEV is $STATE ($PHYS_STATE$RATE)."
+        exit 1
+    }
+
+    for ib_dev in $EXPECTED_IB_DEVS
+    do
+        check_ib $EXPECTED_IB_Gbps $ib_dev
+    done
+
+    echo "IB devices are ok"
+    exit 0
 kind: ConfigMap
 metadata:
   name: node-problem-detector-config

--- a/experimental/aks_npd_draino/npd/deployment/node-problem-detector-config.yaml
+++ b/experimental/aks_npd_draino/npd/deployment/node-problem-detector-config.yaml
@@ -46,9 +46,9 @@ data:
                 "pattern": "divide error: 0000 \\[#\\d+\\] SMP"
             },
             {
-                        "type": "temporary",
-                        "reason": "MemoryReadError",
-                        "pattern": "CE memory read error .*"
+    			"type": "temporary",
+    			"reason": "MemoryReadError",
+    			"pattern": "CE memory read error .*"
             },
             {
                 "type": "permanent",
@@ -258,7 +258,7 @@ data:
     nvlink_status=$(nvidia-smi nvlink --status)
     if [ $? -ne 0 ]; then
        echo "Failed to get NVLINK status with error code $?. FaultCode: NHC2016"
-                exit $NONOK
+       exit $NONOK
     fi
     if [ -z "$nvlink_status" ]; then
        echo "NVLINK is not enabled"
@@ -381,6 +381,202 @@ data:
 
     echo "GPU XID error check passed."
     exit $OK
+  custom-plugin-gpu-ecc.json: |
+    {
+      "plugin": "custom",
+      "pluginConfig": {
+      "invoke_interval": "60s",
+      "timeout": "35s",
+      "max_output_length": 80,
+      "concurrency": 3,
+      "enable_message_change_based_condition_update": false
+      },
+      "source": "custom-plugin-gpu-ecc",
+      "metricsReporting": false,
+      "conditions": [
+        {
+          "type": "GpuEcc",
+          "reason": "GpuEccdGood",
+          "message": "GPU ECC is ok"
+        }
+      ],
+      "rules": [
+        {
+          "type": "temporary",
+          "reason": "GpuEccBad",
+          "path": "./config/plugin/check_gpu_ecc.sh",
+          "timeout": "25s"
+        },
+        {
+          "type": "permanent",
+          "condition": "GpuEcc",
+          "reason": "GpuEccBad",
+          "path": "./config/plugin/check_gpu_ecc.sh",
+          "timeout": "25s"
+        }
+      ]
+    }
+  check_gpu_ecc.sh: |
+    #!/bin/bash
+    # This plugin checks GPU XID errors
+    readonly OK=0
+    readonly NONOK=1
+    readonly UNKNOWN=2
+
+    GPU_REMAPPED_ROWS_QUERY="remapped_rows.pending,remapped_rows.failure,remapped_rows.uncorrectable"
+    GPU_QUERY="ecc.errors.uncorrected.volatile.sram,ecc.errors.uncorrected.aggregate.sram,ecc.errors.uncorrected.volatile.dram,ecc.errors.uncorrected.aggregate.dram,ecc.errors.corrected.volatile.sram,ecc.errors.corrected.aggregate.sram,ecc.errors.corrected.volatile.dram,ecc.errors.corrected.aggregate.dram"
+
+    function collect_ecc_data() {
+       ECC_TYPE=$1
+
+       if [[ $ECC_TYPE == "SDBE" ]]; then
+    # implement collect data
+          page_retirement_query_out=$(nvidia-smi -q -d PAGE_RETIREMENT)
+          page_retirement_query_out_rc=$?
+
+          if [[ $page_retirement_query_out_rc != 0 ]]; then
+             echo "nvidia-smi (get page retirement table) returned error code $page_retirement_query_out_rc. FaultCode: NHCNA"
+             exit $UNKNOWN
+          fi
+          IFS=$'\n'
+          TAB=$'\t'
+          echo ""
+       else
+          gpu_query_out=$(nvidia-smi --query-gpu=$GPU_QUERY --format=csv,noheader)
+          gpu_query_out_rc=$?
+          if [[ $gpu_query_out_rc != 0 ]]
+          then
+          echo "nvidia-smi (get gpu uncorrected counts) returned error code $gpu_query_out_rc. FaultCode: NHCNA"
+          exit $UNKNOWN
+          fi
+          gpu_remapped_rows_out=$(nvidia-smi --query-remapped-rows=$GPU_REMAPPED_ROWS_QUERY --format=csv,noheader)
+          gpu_remapped_rows_out_rc=$?
+          if [[ $gpu_remapped_rows_out_rc != 0 ]]
+          then
+          echo "nvidia-smi (get gpu remapped rows) returned error code $gpu_freq_out_rc. FaultCode: NHCNA"
+          exit $UNKNOWN
+          fi
+          IFS=$'\n'
+          gpu_query_out_lines=( $gpu_query_out )
+          gpu_remapped_rows_query_out_lines=( $gpu_remapped_rows_out )
+          IFS=$' \t\n'
+       fi
+    }
+
+    # ECC checks for A100/H100
+    function check_ecc() {
+
+       collect_ecc_data "ECC"
+
+       ecc_error_threshold=$1
+       ecc_sram_threshold=$2
+
+       if [[ ${#gpu_query_out_lines[*]} != ${#gpu_remapped_rows_query_out_lines[*]} ]]; then
+          echo "nvidia-smi (Number GPU's not correct), (${#gpu_query_out_lines[*]},${#gpu_remapped_rows_query_out_lines[*]}). FaultCode: NHC2007"
+          exit $NONOK
+       fi
+       for ((i=0; i<${#gpu_remapped_rows_query_out_lines[*]}; i++))
+       do
+          IFS=$', '
+          gpu_remapped_rows_query_out_line=( ${gpu_remapped_rows_query_out_lines[$i]} )
+          gpu_query_out_line=( ${gpu_query_out_lines[$i]} )
+          IFS=$' \t\n'
+          if [[ ${gpu_remapped_rows_query_out_line[0]} -gt 0 ]]
+          then
+             echo "GPU id $i: Row remap pending. FaultCode: NHC2007"
+             exit $NONOK
+          fi
+          if [[ ${gpu_remapped_rows_query_out_line[1]} -gt 0 ]]
+          then
+            echo "GPU id $i: Row remap error. FaultCode: NHC2007"
+            exit $NONOK
+          fi
+          echo "GPU id $i: row remap uncorrectable error count, (${gpu_remapped_rows_query_out_line[3]})"
+          if [[ ${gpu_remapped_rows_query_out_line[3]} -gt 512 ]]
+          then
+             echo "GPU id $i: Row remap uncorrectable error count is too high. FaultCode: NHC2007"
+             exit $NONOK
+          fi
+          if [[ ${gpu_query_out_line[4]} -gt $ecc_sram_threshold || ${gpu_query_out_line[5]} -gt $ecc_sram_threshold ]]; then
+             echo "GPU id $i: High SRAM correctable ECC error count detected, (${gpu_query_out_line[4]},${gpu_query_out_line[5]}). FaultCode: NHC2019"
+             exit $NONOK
+          elif [[ ${gpu_query_out_line[0]} -gt 0 || ${gpu_query_out_line[1]} -gt 0 ]]; then
+             echo "GPU id $i: SRAM Uncorrectable ECC error count detected, (${gpu_query_out_line[0]},${gpu_query_out_line[1]}). FaultCode: NHC2019"
+             exit $NONOK
+          else
+             echo "GPU id $i: Normal SRAM Uncorrectable/correctable ECC error count, (${gpu_query_out_line[0]},${gpu_query_out_line[1]},${gpu_query_out_line[4]},${gpu_query_out_line[5]})"
+          fi
+          if [[ -n $ecc_error_threshold ]]; then
+             if [[ ${gpu_query_out_line[2]} -gt $ecc_error_threshold || ${gpu_query_out_line[3]} -gt $ecc_error_threshold || ${gpu_query_out_line[6]} -gt $ecc_error_threshold || ${gpu_query_out_line[7]} -gt $ecc_error_threshold ]]; then
+                echo "GPU id $i: High DRAM Uncorrectable/correctable ECC error count detected, (${gpu_query_out_line[2]},${gpu_query_out_line[3]},${gpu_query_out_line[6]},${gpu_query_out_line[7]}). FaultCode: NHC2019"
+                exit $NONOK
+             else
+                echo "GPU id $i: Normal DRAM Uncorrectable/correctable ECC error count, (${gpu_query_out_line[2]},${gpu_query_out_line[3]},${gpu_query_out_line[6]},${gpu_query_out_line[7]})"
+             fi
+          fi
+       done
+       exit 0
+    }
+
+    function check_SDBE_ecc() {
+       collect_ecc_data "SDBE"
+       flag="false"
+       error_msg=''
+       re='^[0-9]+$'
+
+    # Implement check of collected value against limits
+       gpu_sections=($(echo "$page_retirement_query_out" | awk '/GPU / {print $0}'))
+       sbe_sections=($(echo "$page_retirement_query_out" | awk '/Single Bit ECC / {print $NF}'))
+       dbe_sections=($(echo "$page_retirement_query_out" | awk '/Double Bit ECC / {print $NF}'))
+       ppending_blacklist_sections=($(echo "$page_retirement_query_out" | awk '/Pending Page Blacklist / {print $NF}'))
+
+    # implement SBE DBE total check
+    # Process each GPU section
+       for index in "${!gpu_sections[@]}"; do
+    # Extract SBE and DBE values
+          gpu=${gpu_sections[index]}
+          sbe=${sbe_sections[index]}
+          dbe=${dbe_sections[index]}
+
+          if ! [[ $sbe =~ $re ]] || ! [[ $dbe =~ $re ]]; then
+             continue
+          fi
+
+    # Calculate the sum of SBE and DBE pages
+          total=$((sbe + dbe))
+
+    # implement page retirement check
+    # Check if page blacklist is pending
+          pending=${ppending_blacklist_sections[index]}
+
+          if [ "$total" -ge 62 ] && [ "$pending" == "Yes" ]; then
+             log "$FUNCNAME: Retirement Table Full for, GPU section: GPU=$gpu Total Pages=$total, Pending Blacklist=$pending"
+             flag="true"
+             error_msg+="$TAB : Retirement Table Full for, GPU: $gpu, Total Pages: $total, Pending Blacklist: $pending$IFS"
+          fi
+       done
+
+       if [ "$flag" == "true" ]; then
+          echo "ERROR: $IFS$error_msg. FaultCode: NHC2018"
+          exit $NONOK
+       fi
+
+       exit $OK
+    }
+
+
+    function check_gpu_ecc() {
+       if lspci | grep -i 'VGA\|3D controller'| grep -qi 'V100'; then
+         check_SDBE_ecc
+       else
+         ecc_error_threshold=$1
+         ecc_sram_threshold=$2
+         check_ecc $ecc_error_threshold $ecc_sram_threshold
+       fi
+
+       echo "ECC checks passed"
+       exit $NONOK
+    }
 kind: ConfigMap
 metadata:
   name: node-problem-detector-config

--- a/experimental/aks_npd_draino/npd/deployment/node-problem-detector.yaml
+++ b/experimental/aks_npd_draino/npd/deployment/node-problem-detector.yaml
@@ -1,0 +1,108 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-problem-detector
+  namespace: kube-system
+  labels:
+    app: node-problem-detector
+spec:
+  selector:
+    matchLabels:
+      app: node-problem-detector
+  template:
+    metadata:
+      labels:
+        app: node-problem-detector
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+                  - key: accelerator
+                    operator: In
+                    values:
+                      - nvidia
+      containers:
+      - name: node-problem-detector
+        command:
+        - /node-problem-detector
+        - --logtostderr
+        - --config.custom-plugin-monitor=/config/custom-plugin-gpu-count.json,/config/custom-plugin-gpu-nvlink.json,/config/custom-plugin-gpu-xid.json
+        image: <YOUR ACR>.azurecr.io/k8s-staging-npd/node-problem-detector:<YOUR TAG>
+        resources:
+          limits:
+            cpu: 240m
+            memory: 2048Mi
+          requests:
+            cpu: 240m
+            memory: 2048Mi
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        volumeMounts:
+        - name: log
+          mountPath: /var/log
+          readOnly: true
+        - name: kmsg
+          mountPath: /dev/kmsg
+          readOnly: true
+        # Make sure node problem detector is in the same timezone
+        # with the host.
+        - name: localtime
+          mountPath: /etc/localtime
+          readOnly: true
+        - name: config
+          mountPath: /config
+          readOnly: true
+      serviceAccountName: node-problem-detector
+      volumes:
+      - name: log
+        # Config `log` to your system log directory
+        hostPath:
+          path: /var/log/
+      - name: kmsg
+        hostPath:
+          path: /dev/kmsg
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
+      - name: config
+        configMap:
+          name: node-problem-detector-config
+          defaultMode: 0777
+          items:
+          - key: kernel-monitor.json
+            path: kernel-monitor.json
+          - key: docker-monitor.json
+            path: docker-monitor.json
+          - key: custom-plugin-monitor.json
+            path: custom-plugin-monitor.json
+          - key: check_ntp.sh
+            path: plugin/check_ntp.sh
+          - key: custom-plugin-gpu-count.json
+            path: custom-plugin-gpu-count.json
+          - key: check_gpu_count.sh
+            path: plugin/check_gpu_count.sh
+          - key: custom-plugin-gpu-nvlink.json
+            path: custom-plugin-gpu-nvlink.json
+          - key: check_gpu_nvlink.sh
+            path: plugin/check_gpu_nvlink.sh
+          - key: custom-plugin-gpu-xid.json
+            path: custom-plugin-gpu-xid.json
+          - key: check_gpu_xid.sh
+            path: plugin/check_gpu_xid.sh
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists

--- a/experimental/aks_npd_draino/npd/deployment/node-problem-detector.yaml
+++ b/experimental/aks_npd_draino/npd/deployment/node-problem-detector.yaml
@@ -32,7 +32,7 @@ spec:
         command:
         - /node-problem-detector
         - --logtostderr
-        - --config.custom-plugin-monitor=/config/custom-plugin-gpu-count.json,/config/custom-plugin-gpu-nvlink.json,/config/custom-plugin-gpu-xid.json,/config/custom-plugin-gpu-ecc.json
+        - --config.custom-plugin-monitor=/config/custom-plugin-gpu-count.json,/config/custom-plugin-gpu-nvlink.json,/config/custom-plugin-gpu-xid.json,/config/custom-plugin-gpu-ecc.json,/config/custom-plugin-ib.json
         image: cgacr.azurecr.io/k8s-staging-npd/node-problem-detector:v0.8.19-6-g34e60f82-dirty_8
         resources:
           limits:
@@ -105,6 +105,10 @@ spec:
             path: custom-plugin-gpu-ecc.json
           - key: check_gpu_ecc.sh
             path: plugin/check_gpu_ecc.sh
+          - key: custom-plugin-ib.json
+            path: custom-plugin-ib.json
+          - key: check_ib.sh
+            path: plugin/check_ib.sh
       tolerations:
         - effect: NoSchedule
           operator: Exists

--- a/experimental/aks_npd_draino/npd/deployment/node-problem-detector.yaml
+++ b/experimental/aks_npd_draino/npd/deployment/node-problem-detector.yaml
@@ -32,8 +32,8 @@ spec:
         command:
         - /node-problem-detector
         - --logtostderr
-        - --config.custom-plugin-monitor=/config/custom-plugin-gpu-count.json,/config/custom-plugin-gpu-nvlink.json,/config/custom-plugin-gpu-xid.json
-        image: <YOUR ACR>.azurecr.io/k8s-staging-npd/node-problem-detector:<YOUR TAG>
+        - --config.custom-plugin-monitor=/config/custom-plugin-gpu-count.json,/config/custom-plugin-gpu-nvlink.json,/config/custom-plugin-gpu-xid.json,/config/custom-plugin-gpu-ecc.json
+        image: cgacr.azurecr.io/k8s-staging-npd/node-problem-detector:v0.8.19-6-g34e60f82-dirty_8
         resources:
           limits:
             cpu: 240m
@@ -101,6 +101,10 @@ spec:
             path: custom-plugin-gpu-xid.json
           - key: check_gpu_xid.sh
             path: plugin/check_gpu_xid.sh
+          - key: custom-plugin-gpu-ecc.json
+            path: custom-plugin-gpu-ecc.json
+          - key: check_gpu_ecc.sh
+            path: plugin/check_gpu_ecc.sh
       tolerations:
         - effect: NoSchedule
           operator: Exists

--- a/experimental/aks_npd_draino/readme.md
+++ b/experimental/aks_npd_draino/readme.md
@@ -1,0 +1,36 @@
+# Integration of GPU node health checks into AKS  
+
+Show how to integrate the azurehpc-health-checks GPU tests in k8s node problem detector and then use draino to cordon/drain nodes based on GPU healthc check conditions.
+ 
+## Prerequisites
+
+- AKS cluster (NDmv4) is deployed, see [blog post](https://techcommunity.microsoft.com/t5/azure-high-performance-computing/deploy-ndm-v4-a100-kubernetes-cluster/ba-p/3838871)
+- You will need to replace all references to <YOUR ACR> and <YOUR TAG>  in these scripts.
+
+## Build NPD
+- Use modified NPD Makefile and Dockerfile to build NPD
+```
+BUILD_TAGS="disable_system_log_monitor disable_system_stats_monitor" make 2>&1 | tee make.out
+```
+```
+make push
+```
+>Note: Only a few GPU tests are included, other tests can be easily added.
+
+## Build draino
+```
+docker build -t <YOUR ACR>.azurecr.io/draino .
+docker push <YOUR ACR>.azurecr.io/draino
+```
+
+## Deploy NPD
+```
+kubectl apply -f rbac.yaml
+kubectl apply -f node-problem-detector-config.yaml
+kubectl apply -f node-problem-detector.yaml
+``` 
+
+## Deploy Draino
+```
+kubectl apply -f manifest.yml
+```

--- a/experimental/aks_npd_draino/readme.md
+++ b/experimental/aks_npd_draino/readme.md
@@ -1,8 +1,8 @@
-# Integration of GPU node health checks into AKS  
+# Integration of GPU/IB node health checks into AKS  
 
-Show how to integrate the azurehpc-health-checks GPU tests in k8s node problem detector and then use draino to cordon/drain nodes based on GPU health check conditions.
+Show how to integrate the azurehpc-health-checks GPU/IB tests in k8s node problem detector and then use draino to cordon/drain nodes based on GPU health check conditions.
 
-GPU Count, GPU Nvlink, GPU Xid and GPU ECC health checks are included (other GPU tests can be easily added).
+GPU Count, GPU Nvlink, GPU Xid, GPU ECC and IB health checks are included (other tests can be easily added).
  
 ## Prerequisites
 

--- a/experimental/aks_npd_draino/readme.md
+++ b/experimental/aks_npd_draino/readme.md
@@ -5,7 +5,7 @@ Show how to integrate the azurehpc-health-checks GPU tests in k8s node problem d
 ## Prerequisites
 
 - AKS cluster (NDmv4) is deployed, see [blog post](https://techcommunity.microsoft.com/t5/azure-high-performance-computing/deploy-ndm-v4-a100-kubernetes-cluster/ba-p/3838871)
-- You will need to replace all references to '<YOUR ACR>' and '<YOUR TAG>'  in these scripts.
+- You will need to replace all references to \<YOUR ACR\> and \<YOUR TAG\>  in these scripts.
 
 ## Build NPD
 - Use modified NPD Makefile and Dockerfile to build NPD

--- a/experimental/aks_npd_draino/readme.md
+++ b/experimental/aks_npd_draino/readme.md
@@ -1,6 +1,8 @@
 # Integration of GPU node health checks into AKS  
 
-Show how to integrate the azurehpc-health-checks GPU tests in k8s node problem detector and then use draino to cordon/drain nodes based on GPU healthc check conditions.
+Show how to integrate the azurehpc-health-checks GPU tests in k8s node problem detector and then use draino to cordon/drain nodes based on GPU health check conditions.
+
+GPU Count, GPU Nvlink, GPU Xid and GPU ECC health checks are included (other GPU tests can be easily added).
  
 ## Prerequisites
 

--- a/experimental/aks_npd_draino/readme.md
+++ b/experimental/aks_npd_draino/readme.md
@@ -5,7 +5,7 @@ Show how to integrate the azurehpc-health-checks GPU tests in k8s node problem d
 ## Prerequisites
 
 - AKS cluster (NDmv4) is deployed, see [blog post](https://techcommunity.microsoft.com/t5/azure-high-performance-computing/deploy-ndm-v4-a100-kubernetes-cluster/ba-p/3838871)
-- You will need to replace all references to <YOUR ACR> and <YOUR TAG>  in these scripts.
+- You will need to replace all references to '<YOUR ACR>' and '<YOUR TAG>'  in these scripts.
 
 ## Build NPD
 - Use modified NPD Makefile and Dockerfile to build NPD


### PR DESCRIPTION
Reference implementation of how to integrate Azurehpc-health-checks with AKS.
Azurehpc-health-checks are integrated into k8s node problem detector (NPD) and then draino looks for specific GPU failed conditions and cordons/drains nodes.

NPD and Draino modified scripts are provided.